### PR TITLE
uses clap to simplify CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = ["Mathieu David <mathieudavid@mathieudavid.org>"]
 
 [dependencies]
-getopts = "*"
+clap = "*"
 handlebars = "*"
 rustc-serialize = "*"
 pulldown-cmark = "*"


### PR DESCRIPTION
If you're interested I used [clap](https://github.com/kbknapp/clap-rs) to greatly simplify your CLI. It still has all the same functionality as the original, but far less manual code. It also has some additional functionality "for free" since it's included by default with `clap`

Things like suggestions, where if a user mistakenly types `$ mdbook buld` (note the missing `i` in `build`), this error would appear and exit gracefully:

```
$ mdbook buld
error: The subcommand 'buld' isn't valid
	Did you mean 'build' ?

If you received this message in error, try re-running with 'mdbook -- buld'

USAGE:
	mdbook [FLAGS] <SUBCOMMAND>

For more information try --help
```

There are also things like colored output automatically on linux/osx (Windows works the same, only without color). This color can be turned off too, if you don't like it.

If you'd rather stick with `getopts` no worries, just thought I'd mention it! :) Nice work by the way, I'm excited to see how `mdbook` fleshes out! :+1: 