### PR TITLE
Fix many minor warnings found by clippy

### DIFF
--- a/src/book/bookconfig.rs
+++ b/src/book/bookconfig.rs
@@ -47,10 +47,7 @@ impl BookConfig {
 
         // Just return if an error occured.
         // I would like to propagate the error, but I have to return `&self`
-        match config_file.read_to_string(&mut data) {
-            Err(_) => return self,
-            _ => {},
-        }
+        if let Err(_) = config_file.read_to_string(&mut data) { return self }
 
         // Convert to JSON
         if let Ok(config) = Json::from_str(&data) {

--- a/src/book/bookitem.rs
+++ b/src/book/bookitem.rs
@@ -43,8 +43,8 @@ impl ToJson for Chapter {
 
     fn to_json(&self) -> Json {
         let mut m: BTreeMap<String, Json> = BTreeMap::new();
-        m.insert("name".to_string(), self.name.to_json());
-        m.insert("path".to_string(),self.path.to_str()
+        m.insert("name".to_owned(), self.name.to_json());
+        m.insert("path".to_owned(),self.path.to_str()
             .expect("Json conversion failed for path").to_json()
         );
         m.to_json()
@@ -71,13 +71,13 @@ impl<'a> Iterator for BookItems<'a> {
             } else {
                 let cur = self.items.get(self.current_index).unwrap();
 
-                match cur {
-                    &BookItem::Chapter(_, ref ch) | &BookItem::Affix(ref ch) => {
+                match *cur {
+                    BookItem::Chapter(_, ref ch) | BookItem::Affix(ref ch) => {
                         self.stack.push((self.items, self.current_index));
                         self.items = &ch.sub_items[..];
                         self.current_index = 0;
                     },
-                    &BookItem::Spacer => {
+                    BookItem::Spacer => {
                         self.current_index += 1;
                     }
                 }

--- a/src/book/mdbook.rs
+++ b/src/book/mdbook.rs
@@ -134,9 +134,9 @@ impl MDBook {
         debug!("[*]: constructing paths for missing files");
         for item in self.iter() {
             debug!("[*]: item: {:?}", item);
-            match item {
-                &BookItem::Spacer => continue,
-                &BookItem::Chapter(_, ref ch) | &BookItem::Affix(ref ch) => {
+            match *item {
+                BookItem::Spacer => continue,
+                BookItem::Chapter(_, ref ch) | BookItem::Affix(ref ch) => {
                     if ch.path != PathBuf::new() {
                         let path = self.config.get_src().join(&ch.path);
 
@@ -154,7 +154,7 @@ impl MDBook {
         }
 
         debug!("[*]: init done");
-        return Ok(());
+        Ok(())
     }
 
     /// The `build()` method is the one where everything happens. First it parses `SUMMARY.md` to

--- a/src/parse/summary.rs
+++ b/src/parse/summary.rs
@@ -19,7 +19,7 @@ fn parse_level(summary: &mut Vec<&str>, current_level: i32, mut section: Vec<i32
     let mut items: Vec<BookItem> = vec![];
 
     // Construct the book recursively
-    while summary.len() > 0 {
+    while !summary.is_empty() {
         let item: BookItem;
         // Indentation level of the line to parse
         let level = try!(level(summary[0], 4));
@@ -199,7 +199,7 @@ fn read_link(line: &str) -> Option<(String, PathBuf)> {
         return None
     }
 
-    let name = line[start_delimitor + 1 .. end_delimitor].to_string();
+    let name = line[start_delimitor + 1 .. end_delimitor].to_owned();
 
     start_delimitor = end_delimitor + 1;
     if let Some(i) = line[start_delimitor..].find(')') {
@@ -210,7 +210,7 @@ fn read_link(line: &str) -> Option<(String, PathBuf)> {
         return None
     }
 
-    let path = PathBuf::from(line[start_delimitor + 1 .. end_delimitor].to_string());
+    let path = PathBuf::from(line[start_delimitor + 1 .. end_delimitor].to_owned());
 
     Some((name, path))
 }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -51,17 +51,16 @@ impl Renderer for HtmlHandlebars {
 
         // Check if dest directory exists
         debug!("[*]: Check if destination directory exists");
-        match utils::create_path(book.get_dest()) {
-            Err(_) => return Err(Box::new(io::Error::new(io::ErrorKind::Other, "Unexcpected error when constructing destination path"))),
-            _ => {},
-        };
+        if let Err(_) = utils::create_path(book.get_dest()) {
+            return Err(Box::new(io::Error::new(io::ErrorKind::Other, "Unexpected error when constructing destination path")))
+        }
 
         // Render a file for every entry in the book
         let mut index = true;
         for item in book.iter() {
 
-            match item {
-                &BookItem::Chapter(_, ref ch) | &BookItem::Affix(ref ch) => {
+            match *item {
+                BookItem::Chapter(_, ref ch) | BookItem::Affix(ref ch) => {
                     if ch.path != PathBuf::new() {
 
                         let path = book.get_src().join(&ch.path);
@@ -80,18 +79,18 @@ impl Renderer for HtmlHandlebars {
                         // Remove content from previous file and render content for this one
                         data.remove("path");
                         match ch.path.to_str() {
-                            Some(p) => { data.insert("path".to_string(), p.to_json()); },
+                            Some(p) => { data.insert("path".to_owned(), p.to_json()); },
                             None => return Err(Box::new(io::Error::new(io::ErrorKind::Other, "Could not convert path to str"))),
                         }
 
 
                         // Remove content from previous file and render content for this one
                         data.remove("content");
-                        data.insert("content".to_string(), content.to_json());
+                        data.insert("content".to_owned(), content.to_json());
 
                         // Remove path to root from previous file and render content for this one
                         data.remove("path_to_root");
-                        data.insert("path_to_root".to_string(), utils::path_to_root(&ch.path).to_json());
+                        data.insert("path_to_root".to_owned(), utils::path_to_root(&ch.path).to_json());
 
                         // Rendere the handlebars template with the data
                         debug!("[*]: Render template");
@@ -135,15 +134,15 @@ impl Renderer for HtmlHandlebars {
 
         // Remove content from previous file and render content for this one
         data.remove("path");
-        data.insert("path".to_string(), "print.md".to_json());
+        data.insert("path".to_owned(), "print.md".to_json());
 
         // Remove content from previous file and render content for this one
         data.remove("content");
-        data.insert("content".to_string(), print_content.to_json());
+        data.insert("content".to_owned(), print_content.to_json());
 
         // Remove path to root from previous file and render content for this one
         data.remove("path_to_root");
-        data.insert("path_to_root".to_string(), utils::path_to_root(Path::new("print.md")).to_json());
+        data.insert("path_to_root".to_owned(), utils::path_to_root(Path::new("print.md")).to_json());
 
         // Rendere the handlebars template with the data
         debug!("[*]: Render template");
@@ -199,8 +198,8 @@ fn make_data(book: &MDBook) -> Result<BTreeMap<String,Json>, Box<Error>> {
     debug!("[fn]: make_data");
 
     let mut data  = BTreeMap::new();
-    data.insert("language".to_string(), "en".to_json());
-    data.insert("title".to_string(), book.get_title().to_json());
+    data.insert("language".to_owned(), "en".to_json());
+    data.insert("title".to_owned(), book.get_title().to_json());
 
     let mut chapters = vec![];
 
@@ -208,24 +207,24 @@ fn make_data(book: &MDBook) -> Result<BTreeMap<String,Json>, Box<Error>> {
         // Create the data to inject in the template
         let mut chapter = BTreeMap::new();
 
-        match item {
-            &BookItem::Affix(ref ch) => {
-                chapter.insert("name".to_string(), ch.name.to_json());
+        match *item {
+            BookItem::Affix(ref ch) => {
+                chapter.insert("name".to_owned(), ch.name.to_json());
                 match ch.path.to_str() {
-                    Some(p) => { chapter.insert("path".to_string(), p.to_json()); },
+                    Some(p) => { chapter.insert("path".to_owned(), p.to_json()); },
                     None => return Err(Box::new(io::Error::new(io::ErrorKind::Other, "Could not convert path to str"))),
                 }
             },
-            &BookItem::Chapter(ref s, ref ch) => {
-                chapter.insert("section".to_string(), s.to_json());
-                chapter.insert("name".to_string(), ch.name.to_json());
+            BookItem::Chapter(ref s, ref ch) => {
+                chapter.insert("section".to_owned(), s.to_json());
+                chapter.insert("name".to_owned(), ch.name.to_json());
                 match ch.path.to_str() {
-                    Some(p) => { chapter.insert("path".to_string(), p.to_json()); },
+                    Some(p) => { chapter.insert("path".to_owned(), p.to_json()); },
                     None => return Err(Box::new(io::Error::new(io::ErrorKind::Other, "Could not convert path to str"))),
                 }
             },
-            &BookItem::Spacer => {
-                chapter.insert("spacer".to_string(), "_spacer_".to_json());
+            BookItem::Spacer => {
+                chapter.insert("spacer".to_owned(), "_spacer_".to_json());
             }
 
         }
@@ -233,7 +232,7 @@ fn make_data(book: &MDBook) -> Result<BTreeMap<String,Json>, Box<Error>> {
         chapters.push(chapter);
     }
 
-    data.insert("chapters".to_string(), chapters.to_json());
+    data.insert("chapters".to_owned(), chapters.to_json());
 
     debug!("[*]: JSON constructed");
     Ok(data)

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -37,7 +37,7 @@ pub fn previous(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext
     for item in decoded {
 
         match item.get("path") {
-            Some(path) if path.len() > 0 => {
+            Some(path) if !path.is_empty() => {
                 if path == &current {
 
                     debug!("[*]: Found current chapter");
@@ -51,7 +51,7 @@ pub fn previous(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext
                         match previous.get("name") {
                             Some(n) => {
                                 debug!("[*]: Inserting title: {}", n);
-                                previous_chapter.insert("title".to_string(), n.to_json())
+                                previous_chapter.insert("title".to_owned(), n.to_json())
                             },
                             None => {
                                 debug!("[*]: No title found for chapter");
@@ -67,7 +67,7 @@ pub fn previous(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext
                                 debug!("[*]: Inserting link: {:?}", path);
 
                                 match path.to_str() {
-                                    Some(p) => { previous_chapter.insert("link".to_string(), p.to_json()); },
+                                    Some(p) => { previous_chapter.insert("link".to_owned(), p.to_json()); },
                                     None => return Err(RenderError{ desc: "Link could not be converted to str" })
                                 }
                             },
@@ -134,7 +134,7 @@ pub fn next(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext) ->
 
         match item.get("path") {
 
-            Some(path) if path.len() > 0 => {
+            Some(path) if !path.is_empty() => {
 
                 if let Some(previous) = previous {
 
@@ -153,7 +153,7 @@ pub fn next(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext) ->
                         match item.get("name") {
                             Some(n) => {
                                 debug!("[*]: Inserting title: {}", n);
-                                next_chapter.insert("title".to_string(), n.to_json());
+                                next_chapter.insert("title".to_owned(), n.to_json());
                             }
                             None => return Err(RenderError{ desc: "No title found for chapter in JSON data"})
                         }
@@ -163,7 +163,7 @@ pub fn next(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext) ->
                         debug!("[*]: Inserting link: {:?}", link);
 
                         match link.to_str() {
-                            Some(l) => { next_chapter.insert("link".to_string(), l.to_json()); },
+                            Some(l) => { next_chapter.insert("link".to_owned(), l.to_json()); },
                             None => return Err(RenderError{ desc: "Link could not converted to str"})
                         }
 

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -58,7 +58,7 @@ impl HelperDef for RenderToc {
 
         // Link
         let path_exists = if let Some(path) = item.get("path") {
-            if path.len() > 0 {
+            if !path.is_empty() {
                 try!(rc.writer.write("<a href=\"".as_bytes()));
 
                 // Add link

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -72,7 +72,7 @@ pub fn create_path(path: &Path) -> Result<(), Box<Error>> {
 
     for component in path.components() {
 
-        let mut dir;
+        let dir;
         match component {
             Component::Normal(_) => { dir = PathBuf::from(component.as_os_str()); },
             Component::RootDir => {


### PR DESCRIPTION
Mostly I took whatever suggestions I found because the result seemed good.

I thought dereferencing a match would result in a move so I wasn't sure about:
```rust
// This
match *a {
    A::B => {},
    A::C => {},
}
// Instead of
match a {
    &A::B => {},
    &A::C => {},
}
```
But I tried it and didn't get any errors. I'll have to experiment with it in the future sometime later.