### PR TITLE
adds version for deps to make cargo installable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ exclude = [
 ]
 
 [dependencies]
-clap = "*"
-handlebars = "*"
-rustc-serialize = "*"
-pulldown-cmark = "*"
+clap = "~1.5.3"
+handlebars = "=0.11.2"
+rustc-serialize = "~0.3.16"
+pulldown-cmark = "~0.0.3"
 
 [dev-dependencies]
-tempdir = "*"
+tempdir = "~0.3.4"
 
 [features]
 default = ["output"]


### PR DESCRIPTION
Removes the `*` so this can be installed via `cargo install mdbook`

Also, I locked the `handlebars` dep to `0.11.2` because the current `0.11.3` fails to build.