### PR TITLE
Generalize inline code to all themes

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -270,8 +270,16 @@ h3 {
   }
 }
 .light {
+/* Inline code */
   color: #333;
   background-color: #fff;
+}
+.light :not(pre) > .hljs {
+  display: inline-block;
+  vertical-align: middle;
+  padding: 0.1em 0.3em;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
 }
 .light .sidebar {
   background-color: #fafafa;
@@ -318,8 +326,16 @@ h3 {
   background-color: #e6e6e6;
 }
 .coal {
+/* Inline code */
   color: #98a3ad;
   background-color: #141617;
+}
+.coal :not(pre) > .hljs {
+  display: inline-block;
+  vertical-align: middle;
+  padding: 0.1em 0.3em;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
 }
 .coal .sidebar {
   background-color: #292c2f;
@@ -366,8 +382,16 @@ h3 {
   background-color: #1f2124;
 }
 .navy {
+/* Inline code */
   color: #bcbdd0;
   background-color: #161923;
+}
+.navy :not(pre) > .hljs {
+  display: inline-block;
+  vertical-align: middle;
+  padding: 0.1em 0.3em;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
 }
 .navy .sidebar {
   background-color: #282d3f;
@@ -414,8 +438,16 @@ h3 {
   background-color: #282e40;
 }
 .rust {
+/* Inline code */
   color: #262625;
   background-color: #e1e1db;
+}
+.rust :not(pre) > .hljs {
+  display: inline-block;
+  vertical-align: middle;
+  padding: 0.1em 0.3em;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
 }
 .rust .sidebar {
   background-color: #3b2e2a;

--- a/src/theme/highlight.css
+++ b/src/theme/highlight.css
@@ -10,14 +10,6 @@
   -webkit-text-size-adjust: none;
 }
 
-/* Inline code */
-:not(pre) > .hljs {
-    display: inline-block;
-    vertical-align: middle;
-    padding: 0.1em 0.3em;
-    border-radius: 3px;
-}
-
 
 /* Atelier-Dune Comment */
 .hljs-comment {

--- a/src/theme/stylus/themes/base.styl
+++ b/src/theme/stylus/themes/base.styl
@@ -1,4 +1,12 @@
 .{unquote($theme-name)} {
+    /* Inline code */
+    :not(pre) > .hljs {
+        display: inline-block;
+        vertical-align: middle;
+        padding: 0.1em 0.3em;
+        border-radius: 3px;
+    }
+
     color: $fg
     background-color: $bg
 


### PR DESCRIPTION
As far as I can tell, the top two blocks in `highlight.css` are added/tweaked from the original (included in hightlight.js) while the remaining part of the original css file basically remains identical. The problem is the `:not(pre) > .hljs` isn't included for dark themes which causes issues like https://github.com/azerupi/mdBook/issues/74.

If possible, I'd move away from modified themes so they can just be updated to the latest version of whatever highlight.js is using. I tried backing out the theme tweak but reverted it because the code backgrounds were a weird yellow.

Fixes #74