### PR TITLE
On page load, scroll sidebar to active section. Resolves #21.

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -50,6 +50,13 @@ $( document ).ready(function() {
     });
 
 
+    // Scroll sidebar to current active section
+    var activeSection = sidebar.find(".active");
+    if(activeSection.length) {
+        sidebar.scrollTop(activeSection.offset().top);
+    }
+
+
     // Print button
     $("#print-button").click(function(){
         var printWindow = window.open("print.html");


### PR DESCRIPTION
This bit of js resolves #21 by scrolling the sidebar to the link for the currently-active chapter.

First time contributing to this project, so please excuse anything unexpected. There is some formatting inconsistency in the surrounding js about spaces and quotation marks and whatnot, but I tried to write code that fit in. Please let me know if there's anything that could be improved!