### PR TITLE
Add newlines back in to generated index.html files.

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -114,7 +114,7 @@ impl Renderer for HtmlHandlebars {
 
                             // This could cause a problem when someone displays code containing <base href=...>
                             // on the front page, however this case should be very very rare...
-                            content = content.lines().filter(|line| !line.contains("<base href=")).collect();
+                            content = content.lines().filter(|line| !line.contains("<base href=")).map(|line| line.to_string() + "\n").collect();
 
                             try!(index_file.write_all(content.as_bytes()));
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -114,7 +114,7 @@ impl Renderer for HtmlHandlebars {
 
                             // This could cause a problem when someone displays code containing <base href=...>
                             // on the front page, however this case should be very very rare...
-                            content = content.lines().filter(|line| !line.contains("<base href=")).map(|line| line.to_string() + "\n").collect();
+                            content = content.lines().filter(|line| !line.contains("<base href=")).collect::<Vec<&str>>().join("\n");
 
                             try!(index_file.write_all(content.as_bytes()));
 


### PR DESCRIPTION
This is an inelegant fix for #76. I read about better ways to do this using `intersperse` and `join` but couldn't make the types work out. Happy for someone else to show me a better way.