### PR TITLE
Add anchors around all headers in the content.

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -315,7 +315,7 @@ h3 {
 .light .mobile-nav-chapters {
   background-color: #fafafa;
 }
-.light .content a {
+.light .content a:link {
   color: #4183c4;
 }
 .light .theme-popup {
@@ -371,7 +371,7 @@ h3 {
 .coal .mobile-nav-chapters {
   background-color: #292c2f;
 }
-.coal .content a {
+.coal .content a:link {
   color: #2b79a2;
 }
 .coal .theme-popup {
@@ -427,7 +427,7 @@ h3 {
 .navy .mobile-nav-chapters {
   background-color: #282d3f;
 }
-.navy .content a {
+.navy .content a:link {
   color: #2b79a2;
 }
 .navy .theme-popup {
@@ -483,7 +483,7 @@ h3 {
 .rust .mobile-nav-chapters {
   background-color: #3b2e2a;
 }
-.rust .content a {
+.rust .content a:link {
   color: #2b79a2;
 }
 .rust .theme-popup {

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -28,6 +28,15 @@ $( document ).ready(function() {
     var html = $("html");
     var sidebar = $("#sidebar");
     var page_wrapper = $("#page-wrapper");
+    var content = $("#content");
+
+
+    // Add anchors for all content headers
+    content.find("h1, h2, h3, h4, h5").wrap(function(){
+        var wrapper = $("<a>");
+        wrapper.attr("name", $(this).text());
+        return wrapper;
+    });
 
 
     // Toggle sidebar

--- a/src/theme/stylus/themes/base.styl
+++ b/src/theme/stylus/themes/base.styl
@@ -51,7 +51,7 @@
         background-color: $sidebar-bg
     }
 
-    .content a {
+    .content a:link {
         color: $links
     }
 


### PR DESCRIPTION
This is one way to address #72, creating anchors for sections in the text.

- Just uses the header's text as its anchor name. Spaces in the names work fine in URLs. In the browsers I tested, scrolling to the anchor in the URL works even when the anchor is added after the DOM loads.
- Adjust theme css to only style links, not <a> tags used as anchors.