### PR TITLE
Add navigation by keyboard using alt + left/right arrows

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -23,6 +23,23 @@ $( document ).ready(function() {
         hljs.highlightBlock(block);
     });
 
+    var KEY_CODES = {
+        PREVIOUS_KEY: 37,
+        NEXT_KEY: 39
+    };
+
+    $(document).on('keydown', function (e) {
+        if (e.altKey === true) {
+            switch (e.keyCode) {
+                case KEY_CODES.NEXT_KEY:
+                    window.location.href = $('.nav-chapters.next').attr('href');
+                    break;
+                case KEY_CODES.PREV_KEY:
+                    window.location.href = $('.nav-chapters.previous').attr('href');
+                    break;
+            }
+        }
+    });
 
     // Interesting DOM Elements
     var html = $("html");

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -84,13 +84,13 @@
             </div>
 
             {{#previous}}
-                <a href="{{link}}" class="nav-chapters previous">
+                <a href="{{link}}" class="nav-chapters previous" title="Alt + &larr;">
                     <i class="fa fa-angle-left"></i>
                 </a>
             {{/previous}}
 
             {{#next}}
-                <a href="{{link}}" class="nav-chapters next">
+                <a href="{{link}}" class="nav-chapters next" title="Alt + &rarr;">
                     <i class="fa fa-angle-right"></i>
                 </a>
             {{/next}}


### PR DESCRIPTION
Add navigation to next and previous pages by 'alt + &rarr;' and 'alt + &larr;' combinations. Issue #81 with modification (add alt key)