### PR TITLE
pulldown-mark version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 clap = "~1.5.3"
 handlebars = "~0.12.0"
 rustc-serialize = "~0.3.16"
-pulldown-cmark = "~0.0.5"
+pulldown-cmark = "~0.0.6"
 
 
 # Watch feature


### PR DESCRIPTION
Pulldown-mark with fixed table support: #102 and [google/pulldown-cmark#16](https://github.com/google/pulldown-cmark#16)