### PR TITLE
Generate simple .gitignore on init

### DIFF
--- a/src/bin/mdbook.rs
+++ b/src/bin/mdbook.rs
@@ -94,7 +94,7 @@ fn init(args: &ArgMatches) -> Result<(), Box<Error>> {
     // If flag `--theme` is present, copy theme to src
     if args.is_present("theme") {
 
-        // Skip this id `--force` is present
+        // Skip this if `--force` is present
         if !args.is_present("force") {
             // Print warning
             print!("\nCopying the default theme to {:?}", book.get_src());
@@ -113,6 +113,22 @@ fn init(args: &ArgMatches) -> Result<(), Box<Error>> {
         try!(book.copy_theme());
         println!("\nTheme copied.");
 
+    }
+
+    // Because of `src/book/mdbook.rs#L37-L39`, the following will always evaluate to `true`
+    let is_dest_inside_root = book.get_dest().starts_with(book.get_root());
+
+    if !args.is_present("force") && is_dest_inside_root {
+        let gitignore = book.get_dest().join(".gitignore");
+        println!("\nCreating default .gitignore at {:?}", gitignore);
+        print!("\nAre you sure you want to continue? (y/n) ");
+
+        if confirm() {
+            book.create_gitignore();
+            println!("\n.gitignore created.");
+        } else {
+            println!("\nSkipping...\n");
+        }
     }
 
     println!("\nAll done, no errors...");

--- a/src/book/mdbook.rs
+++ b/src/book/mdbook.rs
@@ -101,6 +101,32 @@ impl MDBook {
         }
 
         {
+            let root = self.config.get_root();
+            let gitignore = root.join(".gitignore");
+
+            if !gitignore.exists() {
+
+                // Gitignore does not exist, create it
+
+                debug!("[*]: {:?} does not exist, trying to create .gitignore", root.join(".gitignore"));
+
+                let dest = self.config.get_dest();
+                // `relative_from` is marked as unstable
+                // http://doc.rust-lang.org/std/path/struct.PathBuf.html#method.relative_from
+                let dest = dest.relative_from(root)
+                    .expect("Destination path does not start with root path.");
+                let dest = dest.to_str()
+                    .expect("No destination path found.");
+
+                let mut f = try!(File::create(&root.join(".gitignore")));
+
+                debug!("[*]: Writing to .gitignore");
+
+                try!(writeln!(f, "{}", dest));
+            }
+        }
+
+        {
             let dest = self.config.get_dest();
             let src = self.config.get_src();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,6 @@
 //!
 //! Make sure to take a look at it.
 
-// Used in `MDBook.init()`
-#![feature(path_relative_from)]
-
 #[macro_use]
 pub mod macros;
 pub mod book;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,9 @@
 //!
 //! Make sure to take a look at it.
 
+// Used in `MDBook.init()`
+#![feature(path_relative_from)]
+
 #[macro_use]
 pub mod macros;
 pub mod book;


### PR DESCRIPTION
Handles: https://github.com/azerupi/mdBook/issues/110

Generates a simple `.gitignore` file inside the book's destination folder with the following contents:

```
# Ignore everything
*

# Except this file
!.gitignore
```

It is intended to instruct git to ignore the auto-generated destination folder's contents.