### PR TITLE
Add description config option

### DIFF
--- a/book-example/book.json
+++ b/book-example/book.json
@@ -1,4 +1,5 @@
 {
     "title": "mdBook Documentation",
+    "description": "Create book from markdown files. Like Gitbook but implemented in Rust",
     "author": "Mathieu David"
 }

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -8,6 +8,7 @@ Here is an example of what a ***book.json*** file might look like:
 {
     "title": "Example book",
     "author": "Name",
+    "description": "The example book covers examples.",
     "dest": "output/my-book"
 }
 ```
@@ -16,6 +17,7 @@ Here is an example of what a ***book.json*** file might look like:
 
 - **title:** title of the book
 - **author:** author of the book
+- **description:** description, which is added as meta in the html head of each page.
 - **dest:** path to the directory where you want your book to be rendered. If a relative path is given it will be relative to the parent directory of the source directory
 
 ***note:*** *the supported configurable parameters are scarce at the moment, but more will be added in the future*

--- a/src/book/bookconfig.rs
+++ b/src/book/bookconfig.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 pub struct BookConfig {
     pub title: String,
     pub author: String,
+    pub description: String,
     root: PathBuf,
     dest: PathBuf,
     src: PathBuf,
@@ -21,6 +22,7 @@ impl BookConfig {
         BookConfig {
             title: String::new(),
             author: String::new(),
+            description: String::new(),
             root: root.to_owned(),
             dest: PathBuf::from("book"),
             src: PathBuf::from("src"),
@@ -54,9 +56,10 @@ impl BookConfig {
             // Extract data
 
             debug!("[*]: Extracting data from config");
-            // Title & author
+            // Title, author, description
             if let Some(a) = config.find_path(&["title"]) { self.title = a.to_string().replace("\"", "") }
             if let Some(a) = config.find_path(&["author"]) { self.author = a.to_string().replace("\"", "") }
+            if let Some(a) = config.find_path(&["description"]) { self.description = a.to_string().replace("\"", "") }
 
             // Destination
             if let Some(a) = config.find_path(&["dest"]) {

--- a/src/book/mdbook.rs
+++ b/src/book/mdbook.rs
@@ -351,6 +351,15 @@ impl MDBook {
         &self.config.author
     }
 
+    pub fn set_description(mut self, description: &str) -> Self {
+        self.config.description = description.to_owned();
+        self
+    }
+    
+    pub fn get_description(&self) -> &str {
+        &self.config.description
+    }
+
     // Construct book
     fn parse_summary(&mut self) -> Result<(), Box<Error>> {
         // When append becomes stable, use self.content.append() ...

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -241,6 +241,7 @@ fn make_data(book: &MDBook) -> Result<BTreeMap<String,Json>, Box<Error>> {
     let mut data  = BTreeMap::new();
     data.insert("language".to_owned(), "en".to_json());
     data.insert("title".to_owned(), book.get_title().to_json());
+    data.insert("description".to_owned(), book.get_description().to_json());
     data.insert("favicon".to_owned(), "favicon.png".to_json());
 
     let mut chapters = vec![];

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <title>{{ title }}</title>
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-        <meta name="description" content="{% block description %}{% endblock %}">
+        <meta name="description" content="{{ description }}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <base href="{{ path_to_root }}">


### PR DESCRIPTION
There seems to be a bug in the index.hbs template.

```
<meta name="description" content="{% block description %}{% endblock %}">
```

I fixed this, adding a `"description": "..."` option to `book.json`.