### PR TITLE
Move `.gitignore` directly under the root folder

### DIFF
--- a/src/bin/mdbook.rs
+++ b/src/bin/mdbook.rs
@@ -115,7 +115,7 @@ fn init(args: &ArgMatches) -> Result<(), Box<Error>> {
 
     }
 
-    // Because of `src/book/mdbook.rs#L37-L39`, the following will always evaluate to `true`
+    // Because of `src/book/mdbook.rs#L37-L39`, `dest` will always start with `root`
     let is_dest_inside_root = book.get_dest().starts_with(book.get_root());
 
     if !args.is_present("force") && is_dest_inside_root {

--- a/src/book/mdbook.rs
+++ b/src/book/mdbook.rs
@@ -166,6 +166,17 @@ impl MDBook {
         if !gitignore.exists() {
             // Gitignore does not exist, create it
 
+            // Because of `src/book/mdbook.rs#L37-L39`, `dest` will always start with `root`. If it
+            // is not, `strip_prefix` will return an Error.
+            if !self.get_dest().starts_with(self.get_root()) {
+                return;
+            }
+
+            let relative = self.get_dest().strip_prefix(self.get_root())
+                .expect("Destination is not relative to root.");
+            let relative = relative.to_str()
+                .expect("Path could not be yielded into a string slice.");
+
             debug!("[*]: {:?} does not exist, trying to create .gitignore", gitignore);
 
             let mut f = File::create(&gitignore)
@@ -173,15 +184,7 @@ impl MDBook {
 
             debug!("[*]: Writing to .gitignore");
 
-            writeln!(f, "# Ignore everything within this folder")
-                .expect("Could not write to file.");
-            writeln!(f, "*")
-                .expect("Could not write to file.");
-            writeln!(f, "")
-                .expect("Could not write to file.");
-            writeln!(f, "# Except this file")
-                .expect("Could not write to file.");
-            writeln!(f, "!.gitignore")
+            writeln!(f, "{}", relative)
                 .expect("Could not write to file.");
         }
     }
@@ -206,7 +209,7 @@ impl MDBook {
 
 
     pub fn get_gitignore(&self) -> PathBuf {
-        self.config.get_dest().join(".gitignore")
+        self.config.get_root().join(".gitignore")
     }
 
     pub fn copy_theme(&self) -> Result<(), Box<Error>> {


### PR DESCRIPTION
Continuation of https://github.com/azerupi/mdBook/pull/111 after [realising a bug in the logic of the implementation](https://github.com/azerupi/mdBook/pull/111#issuecomment-191642716).

---

Generates a `.gitignore` file directly under the `root` folder instead of under the `dest` folder.

Makes use of the newly stabilised ([as of 1.7.0](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-170-2016-03-03) :smile:) [Path.strip_prefix](http://doc.rust-lang.org/nightly/std/path/struct.Path.html#method.strip_prefix) method.