### PR TITLE
travis: use rustup instead of Travis built-in Rust support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 
-language: rust
+language: generic
 
 env:
   global:
@@ -10,73 +10,59 @@ matrix:
   include:
     # Stable channel
     - os: osx
-      env: TARGET=i686-apple-darwin
-      rust: stable
+      env: TARGET=i686-apple-darwin CHANNEL=stable
     - os: linux
-      env: TARGET=i686-unknown-linux-gnu
-      rust: stable
+      env: TARGET=i686-unknown-linux-gnu CHANNEL=stable
       addons:
         apt:
           packages: &i686_unknown_linux_gnu
             - gcc-multilib
     - os: osx
-      env: TARGET=x86_64-apple-darwin
-      rust: stable
+      env: TARGET=x86_64-apple-darwin CHANNEL=stable
     - os: linux
-      env: TARGET=x86_64-unknown-linux-gnu
-      rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu CHANNEL=stable
       addons:
         apt:
           packages:
             - nodejs
             - npm
     - os: linux
-      env: TARGET=x86_64-unknown-linux-musl
-      rust: stable
+      env: TARGET=x86_64-unknown-linux-musl CHANNEL=stable
     # Beta channel
     - os: osx
-      env: TARGET=i686-apple-darwin
-      rust: beta
+      env: TARGET=i686-apple-darwin CHANNEL=beta
     - os: linux
-      env: TARGET=i686-unknown-linux-gnu
-      rust: beta
+      env: TARGET=i686-unknown-linux-gnu CHANNEL=beta
       addons:
         apt:
           packages: *i686_unknown_linux_gnu
     - os: osx
-      env: TARGET=x86_64-apple-darwin
-      rust: beta
+      env: TARGET=x86_64-apple-darwin CHANNEL=beta
     - os: linux
-      env: TARGET=x86_64-unknown-linux-gnu
-      rust: beta
+      env: TARGET=x86_64-unknown-linux-gnu CHANNEL=beta
     - os: linux
-      env: TARGET=x86_64-unknown-linux-musl
-      rust: beta
+      env: TARGET=x86_64-unknown-linux-musl CHANNEL=beta
     # Nightly channel
     - os: osx
-      env: TARGET=i686-apple-darwin
-      rust: nightly
+      env: TARGET=i686-apple-darwin CHANNEL=nightly
     - os: linux
-      env: TARGET=i686-unknown-linux-gnu
-      rust: nightly
+      env: TARGET=i686-unknown-linux-gnu CHANNEL=nightly
       addons:
         apt:
           packages: *i686_unknown_linux_gnu
     - os: osx
-      env: TARGET=x86_64-apple-darwin
-      rust: nightly
+      env: TARGET=x86_64-apple-darwin CHANNEL=nightly
     - os: linux
-      env: TARGET=x86_64-unknown-linux-gnu
-      rust: nightly
+      env: TARGET=x86_64-unknown-linux-gnu CHANNEL=nightly
     - os: linux
-      env: TARGET=x86_64-unknown-linux-musl
-      rust: nightly
+      env: TARGET=x86_64-unknown-linux-musl CHANNEL=nightly
 
 install:
-  - sh ci/install.sh
+  - export PATH="$PATH:$HOME/.cargo/bin"
+  - bash ci/install.sh
 
 script:
-  - sh ci/script.sh
+  - bash ci/script.sh
 
 after_success:
   - test $TRAVIS_PULL_REQUEST == "false" &&
@@ -87,7 +73,7 @@ after_success:
     bash deploy.sh
 
 before_deploy:
-  - sh ci/before_deploy.sh
+  - bash ci/before_deploy.sh
 
 deploy:
   provider: releases
@@ -98,7 +84,7 @@ deploy:
   skip_cleanup: true
   # deploy when a new tag is pushed
   on:
-    condition: $TRAVIS_RUST_VERSION = stable
+    condition: $CHANNEL = stable
     tags: true
 
 notifications:

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -2,12 +2,31 @@
 
 set -ex
 
-cargo build --target $TARGET --release
+mktempd() {
+  echo $(mktemp -d 2>/dev/null || mktemp -d -t tmp)
+}
 
-mkdir staging
+mk_artifacts() {
+  cargo build --target $TARGET --release
+}
 
-cp target/$TARGET/release/mdbook staging
+mk_tarball() {
+  local td=$(mktempd)
+  local out_dir=$(pwd)
 
-cd staging
+  cp target/$TARGET/release/mdbook $td
 
-tar czf ../${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz *
+  pushd $td
+
+  tar czf $out_dir/${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz *
+
+  popd $td
+  rm -r $td
+}
+
+main() {
+  mk_artifacts
+  mk_tarball
+}
+
+main

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -2,32 +2,57 @@
 
 set -ex
 
-case $TARGET in
-  # Install standard libraries needed for cross compilation
-  i686-apple-darwin | \
-  i686-unknown-linux-gnu | \
-  x86_64-unknown-linux-musl)
-    case $TRAVIS_RUST_VERSION in
-      stable)
-        # e.g. 1.6.0
-        version=$(rustc -V | cut -d' ' -f2)
-        ;;
-      *)
-        version=$TRAVIS_RUST_VERSION
-        ;;
-    esac
-    tarball=rust-std-${version}-${TARGET}
-
-    curl -Os http://static.rust-lang.org/dist/${tarball}.tar.gz
-
-    tar xzf ${tarball}.tar.gz
-
-    ${tarball}/install.sh --prefix=$(rustc --print sysroot)
-
-    rm -r ${tarball}
-    rm ${tarball}.tar.gz
+case "$TRAVIS_OS_NAME" in
+  linux)
+    host=x86_64-unknown-linux-gnu
     ;;
-  # Nothing to do for native builds
-  *)
+  osx)
+    host=x86_64-apple-darwin
     ;;
 esac
+
+mktempd() {
+  echo $(mktemp -d 2>/dev/null || mktemp -d -t tmp)
+}
+
+install_rustup() {
+  local td=$(mktempd)
+
+  pushd $td
+  curl -O https://static.rust-lang.org/rustup/dist/$host/rustup-setup
+  chmod +x rustup-setup
+  ./rustup-setup -y
+  popd
+
+  rm -r $td
+
+  rustup default $CHANNEL
+  rustc -V
+  cargo -V
+}
+
+install_standard_crates() {
+  if [ "$host" != "$TARGET" ]; then
+    if [ ! "$CHANNEL" = "stable" ]; then
+      rustup target add $TARGET
+    else
+      local version=$(rustc -V | cut -d' ' -f2)
+      local tarball=rust-std-${version}-${TARGET}
+
+      local td=$(mktempd)
+      curl -s https://static.rust-lang.org/dist/${tarball}.tar.gz | \
+        tar --strip-components 1 -C $td -xz
+
+      $td/install.sh --prefix=$(rustc --print sysroot)
+
+      rm -r $td
+    fi
+  fi
+}
+
+main() {
+  install_rustup
+  install_standard_crates
+}
+
+main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,23 +2,36 @@
 
 set -ex
 
-case "$TRAVIS_OS_NAME" in
-  linux)
-    host=x86_64-unknown-linux-gnu
-    ;;
-  osx)
-    host=x86_64-apple-darwin
-    ;;
-esac
+# NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
+# This has been fixed in the nightly channel but it would take a while to reach the other channels
+disable_cross_doctests() {
+  local host
+  case "$TRAVIS_OS_NAME" in
+    linux)
+      host=x86_64-unknown-linux-gnu
+      ;;
+    osx)
+      host=x86_64-apple-darwin
+      ;;
+  esac
 
-# NOTE Workaround for rust-lang/rust#31907 - disable doc tests when crossing
-if [ "$host" != "$TARGET" ]; then
-  if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    brew install gnu-sed --default-names
+  if [ "$host" != "$TARGET" ] && [ "$CHANNEL" != "nightly" ]; then
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      brew install gnu-sed --default-names
+    fi
+
+    find src -name '*.rs' -type f | xargs sed -i -e 's:\(//.\s*```\):\1 ignore,:g'
   fi
+}
 
-  find src -name '*.rs' -type f | xargs sed -i -e 's:\(//.\s*```\):\1 ignore,:g'
-fi
+run_test_suite() {
+  cargo build --target $TARGET --verbose
+  cargo test --target $TARGET --verbose
+}
 
-cargo build --target $TARGET --verbose
-cargo test --target $TARGET --verbose
+main() {
+  disable_cross_doctests
+  run_test_suite
+}
+
+main


### PR DESCRIPTION
this ensures we install the correct set of standard crates when working
in the beta channel