### PR TITLE
Fix no-default-features build

### DIFF
--- a/src/bin/mdbook.rs
+++ b/src/bin/mdbook.rs
@@ -2,13 +2,14 @@
 extern crate mdbook;
 #[macro_use]
 extern crate clap;
-extern crate crossbeam;
 
 // Dependencies for the Watch feature
 #[cfg(feature = "watch")]
 extern crate notify;
 #[cfg(feature = "watch")]
 extern crate time;
+#[cfg(feature = "watch")]
+extern crate crossbeam;
 
 // Dependencies for the Serve feature
 #[cfg(feature = "serve")]
@@ -269,6 +270,7 @@ fn get_book_dir(args: &ArgMatches) -> PathBuf {
 
 
 // Calls the closure when a book source file is changed. This is blocking!
+#[cfg(feature = "watch")]
 fn trigger_on_change<F>(book: &mut MDBook, closure: F) -> ()
     where F: Fn(notify::Event, &mut MDBook) -> ()
 {

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -28,7 +28,6 @@ pub struct MDBook {
     pub content: Vec<BookItem>,
     renderer: Box<Renderer>,
 
-    #[cfg(feature = "serve")]
     livereload: Option<String>,
 }
 
@@ -57,6 +56,7 @@ impl MDBook {
 
             content: vec![],
             renderer: Box::new(HtmlHandlebars::new()),
+
             livereload: None,
         }
     }


### PR DESCRIPTION
I believe it's currently not possible to do leave out the livereload field as it's used in other parts of the code where we can't utilize conditional compilation without ugly hacks.

Fixes: #136 

related: https://github.com/rust-lang/rust/issues/15701