### PR TITLE
Use light theme when javascript is disabled

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -31,7 +31,7 @@
             }
         </script>
     </head>
-    <body>
+    <body class="light">
         <!-- Set the theme before any content is loaded, prevents flash -->
         <script type="text/javascript">
             var theme = localStorage.getItem('theme');


### PR DESCRIPTION
mdBook is setting theme (by adding a class attribute to body tag) with javascript.
Page is not using any theme by default and page is not using any styling unless
javascript is enabled.

This patch is adding class attribute to body tag and making mdBook to use `light`
theme when javascript is disabled.

Fixes: #144