### PR TITLE
Fixes #156 - anchors are now URI encoded

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -57,7 +57,9 @@ $( document ).ready(function() {
         var wrapper = $("<a class=\"header\">");
         wrapper.attr("name", $(this).text());
         // Add so that when you click the link actually shows up in the url bar...
-        wrapper.attr("href", $(location).attr('href') + "#" + $(this).text());
+        // Remove any existing anchor then append the new one
+        // ensuring eg. no spaces are present within it ie. they become %20
+        wrapper.attr("href", $(location).attr('href').split("#")[0] + "#" + encodeURIComponent($(this).text().trim()) );
         return wrapper;
     });
 


### PR DESCRIPTION
also fixes https://github.com/rust-lang/book/issues/166 anchors duplication

Thanks @azerupi for mentoring in #156 !
Cheers!


Note: `split("#")[0]` does return the full url if there are no `#` (anchor) to strip out - just making sure that case was handled :)