### PR TITLE
Exit with a nonzero status if we get an error

### DIFF
--- a/src/bin/mdbook.rs
+++ b/src/bin/mdbook.rs
@@ -83,6 +83,7 @@ fn main() {
 
     if let Err(e) = res {
         writeln!(&mut io::stderr(), "An error occured:\n{}", e).ok();
+        ::std::process::exit(101);
     }
 }
 


### PR DESCRIPTION
A branch of the book had [a code example that failed with `mdbook test`, but travis reported a success](https://travis-ci.org/rust-lang/book/jobs/149313558). This is because the exit status of `mdbook test` (and other commands) is still 0 even when there are errors.

I [made a little repo](https://github.com/carols10cents/mdbook-test-exit-status) that has an example to test with, but the book-example in this repo also currently has an error with `mdbook test` 😱

Before this patch, if I run `mdbook test` on those, I get an exit status of 0 when I expect to get nonzero. After this patch, I get the nonzero exit status that I expected (I went with 101 because that's what `rustdoc --test` returns if it fails), and I continue to get an exit status of 0 when running `mdbook test` on a book that passes its tests.

This does affect all commands. I'm not sure if others were already exiting as expected when encountering errors or not. It looks like `watch` might.

I didn't see any automated tests that actually run the binaries-- please point me to the appropriate place to add tests if I missed them!

