### PR TITLE
slugify section headers

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -55,11 +55,12 @@ $( document ).ready(function() {
     // Add anchors for all content headers
     content.find("h1, h2, h3, h4, h5").wrap(function(){
         var wrapper = $("<a class=\"header\">");
-        wrapper.attr("name", $(this).text());
+        var header_name = $(this).text().trim().replace(/\W/g, '-')
+        wrapper.attr("name", header_name);
         // Add so that when you click the link actually shows up in the url bar...
         // Remove any existing anchor then append the new one
         // ensuring eg. no spaces are present within it ie. they become %20
-        wrapper.attr("href", $(location).attr('href').split("#")[0] + "#" + encodeURIComponent($(this).text().trim()) );
+        wrapper.attr("href", $(location).attr('href').split("#")[0] + "#" + header_name );
         return wrapper;
     });
 


### PR DESCRIPTION
The current section headers are url encoded.  Because of that they
have some funny characters like %20.  We can clean that up by removing
all of the non-word characters before placing them in the anchor.

I originally planned to use `/\s/g` as the regex to preserve other url encoded characters like ‰ or ¥ that might be useful, but I double checked what Github does on gists and it looks like they strip everything.

hi ‰ there

becomes #hi--there in the url.

mdbook urls will now match that style.

fixes #168