### PR TITLE
Remove unused metadata import

### DIFF
--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, Component};
 use std::error::Error;
 use std::io::{self, Read};
-use std::fs::{self, metadata, File};
+use std::fs::{self, File};
 
 /// Takes a path to a file and try to read the file into a String
 


### PR DESCRIPTION
PR removes warning:

```rust
warning: unused import, #[warn(unused_imports)] on by default
 --> src/utils/fs.rs:4:21
  |
4 | use std::fs::{self, metadata, File};
  |                     ^^^^^^^^
```

It's really unused.