### PR TITLE
Switch from rustc_serialize to serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ exclude = [
 
 [dependencies]
 clap = "2.2.1"
-handlebars = "0.20.0"
-rustc-serialize = "0.3.18"
+handlebars = { version = "0.20.0", features = ["serde_type"] }
+serde = "0.8.17"
+serde_json = "0.8.3"
 pulldown-cmark = "0.0.8"
 log = "0.3"
 env_logger = "0.3.4"

--- a/src/book/bookconfig.rs
+++ b/src/book/bookconfig.rs
@@ -1,5 +1,4 @@
 use serde_json;
-use serde_json::Value;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};

--- a/src/book/bookconfig.rs
+++ b/src/book/bookconfig.rs
@@ -1,4 +1,5 @@
-use rustc_serialize::json::Json;
+use serde_json;
+use serde_json::Value;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -53,23 +54,25 @@ impl BookConfig {
         }
 
         // Convert to JSON
-        if let Ok(config) = Json::from_str(&data) {
+        if let Ok(config) = serde_json::from_str::<serde_json::Value>(&data) {
             // Extract data
+
+            let config = config.as_object().unwrap();
 
             debug!("[*]: Extracting data from config");
             // Title, author, description
-            if let Some(a) = config.find_path(&["title"]) {
+            if let Some(a) = config.get("title") {
                 self.title = a.to_string().replace("\"", "")
             }
-            if let Some(a) = config.find_path(&["author"]) {
+            if let Some(a) = config.get("author") {
                 self.author = a.to_string().replace("\"", "")
             }
-            if let Some(a) = config.find_path(&["description"]) {
+            if let Some(a) = config.get("description") {
                 self.description = a.to_string().replace("\"", "")
             }
 
             // Destination
-            if let Some(a) = config.find_path(&["dest"]) {
+            if let Some(a) = config.get("dest") {
                 let dest = PathBuf::from(&a.to_string().replace("\"", ""));
 
                 // If path is relative make it absolute from the parent directory of src

--- a/src/book/bookitem.rs
+++ b/src/book/bookitem.rs
@@ -1,6 +1,5 @@
 use serde::{Serialize, Serializer};
 use std::path::PathBuf;
-use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
 pub enum BookItem {

--- a/src/book/bookitem.rs
+++ b/src/book/bookitem.rs
@@ -1,4 +1,4 @@
-use rustc_serialize::json::{Json, ToJson};
+use serde::{Serialize, Serializer};
 use std::path::PathBuf;
 use std::collections::BTreeMap;
 
@@ -36,16 +36,12 @@ impl Chapter {
 }
 
 
-impl ToJson for Chapter {
-    fn to_json(&self) -> Json {
-        let mut m: BTreeMap<String, Json> = BTreeMap::new();
-        m.insert("name".to_owned(), self.name.to_json());
-        m.insert("path".to_owned(),
-                 self.path
-                     .to_str()
-                     .expect("Json conversion failed for path")
-                     .to_json());
-        m.to_json()
+impl Serialize for Chapter {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+        let mut state = try!(serializer.serialize_struct("Chapter", 2));
+        try!(serializer.serialize_struct_elt(&mut state, "name", self.name.clone()));
+        try!(serializer.serialize_struct_elt(&mut state, "path", self.path.clone()));
+        serializer.serialize_struct_end(state)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,8 @@
 //!
 //! Make sure to take a look at it.
 
-extern crate rustc_serialize;
+extern crate serde;
+extern crate serde_json;
 extern crate handlebars;
 extern crate pulldown_cmark;
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -12,7 +12,6 @@ use std::collections::BTreeMap;
 
 use handlebars::Handlebars;
 
-use serde::Serialize;
 use serde_json;
 use serde_json::value::ToJson;
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -11,7 +11,10 @@ use std::io::{self, Read, Write};
 use std::collections::BTreeMap;
 
 use handlebars::Handlebars;
-use rustc_serialize::json::{Json, ToJson};
+
+use serde::Serialize;
+use serde_json;
+use serde_json::value::ToJson;
 
 
 pub struct HtmlHandlebars;
@@ -276,10 +279,10 @@ impl Renderer for HtmlHandlebars {
     }
 }
 
-fn make_data(book: &MDBook) -> Result<BTreeMap<String, Json>, Box<Error>> {
+fn make_data(book: &MDBook) -> Result<serde_json::Map<String, serde_json::Value>, Box<Error>> {
     debug!("[fn]: make_data");
 
-    let mut data = BTreeMap::new();
+    let mut data = serde_json::Map::new();
     data.insert("language".to_owned(), "en".to_json());
     data.insert("title".to_owned(), book.get_title().to_json());
     data.insert("description".to_owned(), book.get_description().to_json());

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 use std::collections::BTreeMap;
 
-use rustc_serialize::json::{self, ToJson};
+use serde_json;
+use serde_json::value::ToJson;
 use handlebars::{Handlebars, RenderError, RenderContext, Helper, Context, Renderable};
 
 // Handlebars helper for navigation
@@ -22,7 +23,7 @@ pub fn previous(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext
 
     debug!("[*]: Decode chapters from JSON");
     // Decode json format
-    let decoded: Vec<BTreeMap<String, String>> = match json::decode(&chapters.to_string()) {
+    let decoded: Vec<BTreeMap<String, String>> = match serde_json::from_str(&chapters.to_string()) {
         Ok(data) => data,
         Err(_) => return Err(RenderError::new("Could not decode the JSON data")),
     };
@@ -121,7 +122,7 @@ pub fn next(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext) ->
 
     debug!("[*]: Decode chapters from JSON");
     // Decode json format
-    let decoded: Vec<BTreeMap<String, String>> = match json::decode(&chapters.to_string()) {
+    let decoded: Vec<BTreeMap<String, String>> = match serde_json::from_str(&chapters.to_string()) {
         Ok(data) => data,
         Err(_) => return Err(RenderError::new("Could not decode the JSON data")),
     };

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::collections::BTreeMap;
 
-use rustc_serialize::json;
+use serde_json;
 use handlebars::{Handlebars, HelperDef, RenderError, RenderContext, Helper, Context};
 use pulldown_cmark::{Parser, html, Event, Tag};
 
@@ -20,7 +20,7 @@ impl HelperDef for RenderToc {
         try!(rc.writer.write("<ul class=\"chapter\">".as_bytes()));
 
         // Decode json format
-        let decoded: Vec<BTreeMap<String, String>> = json::decode(&chapters.to_string()).unwrap();
+        let decoded: Vec<BTreeMap<String, String>> = serde_json::from_str(&chapters.to_string()).unwrap();
 
         let mut current_level = 1;
 


### PR DESCRIPTION
This PR switches from rustc-serialize to serde. We actually don't even need codegen from serde. Only the `Chapter` struct had to implement `Serialize` but that was trivial to do.