### PR TITLE
Add hljs class to all code blocks, regardless of highlighting

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -22,6 +22,10 @@ $( document ).ready(function() {
     $('code').each(function(i, block) {
         hljs.highlightBlock(block);
     });
+    
+    // Adding the hljs class gives code blocks the color css
+    // even if highlighting doesn't apply
+    $('code').addClass('hljs');
 
     var KEY_CODES = {
         PREVIOUS_KEY: 37,


### PR DESCRIPTION
Fixes #179.

Highlight.js does not apply syntax highlighting to code blocks marked
no-highlight, nohighlight, plain, or text. When it finds blocks of those
languages, it does not add the `hljs` class to those code blocks either.

highlight.css and tomorrow-night.css use the `hljs` class to give code
blocks their backrgound color and text color, and we want that to apply
even if the code doesn't get syntax highlighting markup.

This is a somewhat hacky solution to get just that behavior! After this
commit, code blocks with no-highlight, nohighlight, plain, or text
language set on them will indeed get the hljs colors.