### PR TITLE
Parse toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,14 @@ exclude = [
 ]
 
 [dependencies]
-clap = "2.2.1"
-handlebars = { version = "0.20.0", features = ["serde_type"] }
-serde = "0.8.17"
-serde_json = "0.8.3"
+clap = "2.19.2"
+handlebars = { version = "0.23.0", features = ["serde_type"] }
+serde = "0.8"
+serde_json = "0.8"
 pulldown-cmark = "0.0.8"
 log = "0.3"
-env_logger = "0.3.4"
+env_logger = "0.3"
+toml = { version = "0.2", features = ["serde"] }
 
 # Watch feature
 notify = { version = "2.5.5", optional = true }
@@ -33,11 +34,9 @@ iron = { version = "0.4", optional = true }
 staticfile = { version = "0.3", optional = true }
 ws = { version = "0.5.1", optional = true}
 
-
 # Tests
 [dev-dependencies]
 tempdir = "0.3.4"
-
 
 [features]
 default = ["output", "watch", "serve"]

--- a/book-example/book.json
+++ b/book-example/book.json
@@ -1,5 +1,0 @@
-{
-    "title": "mdBook Documentation",
-    "description": "Create book from markdown files. Like Gitbook but implemented in Rust",
-    "author": "Mathieu David"
-}

--- a/book-example/book.toml
+++ b/book-example/book.toml
@@ -1,0 +1,3 @@
+title = "mdBook Documentation"
+description = "Create book from markdown files. Like Gitbook but implemented in Rust"
+author = "Mathieu David"

--- a/book-example/src/SUMMARY.md
+++ b/book-example/src/SUMMARY.md
@@ -1,5 +1,7 @@
 # Summary
 
+[Introduction](misc/introduction.md)
+
 - [mdBook](README.md)
 - [Command Line Tool](cli/cli-tool.md)
     - [init](cli/init.md)

--- a/book-example/src/cli/test.md
+++ b/book-example/src/cli/test.md
@@ -10,7 +10,7 @@ mdBook supports a `test` command that will run all available tests in mdBook. At
 - checking for unused files
 - ...
 
-In the future I would like the user to be able to enable / disable test from the `book.json` configuration file and support custom tests.
+In the future I would like the user to be able to enable / disable test from the `book.toml` configuration file and support custom tests.
 
 **How to use it:**
 ```bash

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -1,16 +1,16 @@
 # Configuration
 
-You can configure the parameters for your book in the ***book.json*** file.
+You can configure the parameters for your book in the ***book.toml*** file.
 
-Here is an example of what a ***book.json*** file might look like:
+We encourage using the TOML format, but JSON is also recognized and parsed.
 
-```json
-{
-    "title": "Example book",
-    "author": "Name",
-    "description": "The example book covers examples.",
-    "dest": "output/my-book"
-}
+Here is an example of what a ***book.toml*** file might look like:
+
+```toml
+title = "Example book"
+author = "Name"
+description = "The example book covers examples."
+dest = "output/my-book"
 ```
 
 #### Supported variables

--- a/book-example/src/format/format.md
+++ b/book-example/src/format/format.md
@@ -4,5 +4,5 @@ In this section you will learn how to:
 
 - Structure your book correctly
 - Format your `SUMMARY.md` file
-- Configure your book using `book.json`
+- Configure your book using `book.toml`
 - Customize your theme

--- a/book-example/src/format/theme/index-hbs.md
+++ b/book-example/src/format/theme/index-hbs.md
@@ -19,7 +19,7 @@ Here is a list of the properties that are exposed:
 
 - ***language*** Language of the book in the form `en`. To use in <code class="language-html">\<html lang="{{ language }}"></code> for example.
 At the moment it is hardcoded.
-- ***title*** Title of the book, as specified in `book.json`
+- ***title*** Title of the book, as specified in `book.toml`
 
 - ***path*** Relative path to the original markdown file from the source directory
 - ***content*** This is the rendered markdown.

--- a/book-example/src/format/theme/syntax-highlighting.md
+++ b/book-example/src/format/theme/syntax-highlighting.md
@@ -47,7 +47,7 @@ Will render as
 # }
 ```
 
-**At the moment, this only works for code examples that are annotated with `rust`. Because it would collide with semantics of some programming languages. In the future, we want to make this configurable through the `book.json` so that everyone can benefit from it.**
+**At the moment, this only works for code examples that are annotated with `rust`. Because it would collide with semantics of some programming languages. In the future, we want to make this configurable through the `book.toml` so that everyone can benefit from it.**
 
 
 ## Improve default theme

--- a/book-example/src/lib/lib.md
+++ b/book-example/src/lib/lib.md
@@ -13,7 +13,7 @@ fn main() {
     let mut book =  MDBook::new(Path::new("my-book"))   // Path to root
                         .set_src(Path::new("src"))      // Path from root to source directory
                         .set_dest(Path::new("book"))    // Path from root to output directory
-                        .read_config();                 // Parse book.json file for configuration
+                        .read_config();                 // Parse book.toml or book.json file for configuration
 
     book.build().unwrap();                              // Render the book
 }

--- a/book-example/src/misc/introduction.md
+++ b/book-example/src/misc/introduction.md
@@ -1,0 +1,3 @@
+# Introduction
+
+A frontmatter chapter.

--- a/src/book/bookconfig_test.rs
+++ b/src/book/bookconfig_test.rs
@@ -20,9 +20,9 @@ fn it_parses_json_config() {
 
     let expected = r#"BookConfig {
     root: ".",
-    dest: "./book",
-    src: "./src",
-    theme_path: "./theme",
+    dest: "book",
+    src: "src",
+    theme_path: "theme",
     title: "mdBook Documentation",
     author: "Mathieu David",
     description: "Create book from markdown files. Like Gitbook but implemented in Rust",
@@ -46,13 +46,11 @@ author = "Mathieu David"
 
     config.parse_from_toml_string(&text.to_string());
 
-    println!("{:#?}", config);
-
     let expected = r#"BookConfig {
     root: ".",
-    dest: "./book",
-    src: "./src",
-    theme_path: "./theme",
+    dest: "book",
+    src: "src",
+    theme_path: "theme",
     title: "mdBook Documentation",
     author: "Mathieu David",
     description: "Create book from markdown files. Like Gitbook but implemented in Rust",

--- a/src/book/bookconfig_test.rs
+++ b/src/book/bookconfig_test.rs
@@ -1,0 +1,63 @@
+#[cfg(test)]
+
+use std::path::Path;
+use book::bookconfig::*;
+
+#[test]
+fn it_parses_json_config() {
+    let text = r#"
+{
+    "title": "mdBook Documentation",
+    "description": "Create book from markdown files. Like Gitbook but implemented in Rust",
+    "author": "Mathieu David"
+}"#;
+
+    // TODO don't require path argument, take pwd
+    let mut config = BookConfig::new(Path::new("."));
+
+    config.parse_from_json_string(&text.to_string());
+
+    let expected = r#"BookConfig {
+    root: ".",
+    dest: "./book",
+    src: "./src",
+    theme_path: "./theme",
+    title: "mdBook Documentation",
+    author: "Mathieu David",
+    description: "Create book from markdown files. Like Gitbook but implemented in Rust",
+    indent_spaces: 4,
+    multilingual: false
+}"#;
+
+    assert_eq!(format!("{:#?}", config), expected);
+}
+
+#[test]
+fn it_parses_toml_config() {
+    let text = r#"
+title = "mdBook Documentation"
+description = "Create book from markdown files. Like Gitbook but implemented in Rust"
+author = "Mathieu David"
+"#;
+
+    // TODO don't require path argument, take pwd
+    let mut config = BookConfig::new(Path::new("."));
+
+    config.parse_from_toml_string(&text.to_string());
+
+    println!("{:#?}", config);
+
+    let expected = r#"BookConfig {
+    root: ".",
+    dest: "./book",
+    src: "./src",
+    theme_path: "./theme",
+    title: "mdBook Documentation",
+    author: "Mathieu David",
+    description: "Create book from markdown files. Like Gitbook but implemented in Rust",
+    indent_spaces: 4,
+    multilingual: false
+}"#;
+
+    assert_eq!(format!("{:#?}", config), expected);
+}

--- a/src/book/bookconfig_test.rs
+++ b/src/book/bookconfig_test.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 
 use std::path::Path;
+use serde_json;
 use book::bookconfig::*;
 
 #[test]
@@ -60,4 +61,305 @@ author = "Mathieu David"
 }"#;
 
     assert_eq!(format!("{:#?}", config), expected);
+}
+
+#[test]
+fn it_parses_json_nested_array_to_toml() {
+
+    // Example from:
+    // toml-0.2.1/tests/valid/arrays-nested.json
+
+    let text = r#"
+{
+    "nest": {
+        "type": "array",
+        "value": [
+            {"type": "array", "value": [
+                {"type": "string", "value": "a"}
+            ]},
+            {"type": "array", "value": [
+                {"type": "string", "value": "b"}
+            ]}
+        ]
+    }
+}"#;
+
+    let c: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+    let result = json_object_to_btreemap(&c.as_object().unwrap());
+
+    let expected = r#"{
+    "nest": Table(
+        {
+            "type": String(
+                "array"
+            ),
+            "value": Array(
+                [
+                    Table(
+                        {
+                            "type": String(
+                                "array"
+                            ),
+                            "value": Array(
+                                [
+                                    Table(
+                                        {
+                                            "type": String(
+                                                "string"
+                                            ),
+                                            "value": String(
+                                                "a"
+                                            )
+                                        }
+                                    )
+                                ]
+                            )
+                        }
+                    ),
+                    Table(
+                        {
+                            "type": String(
+                                "array"
+                            ),
+                            "value": Array(
+                                [
+                                    Table(
+                                        {
+                                            "type": String(
+                                                "string"
+                                            ),
+                                            "value": String(
+                                                "b"
+                                            )
+                                        }
+                                    )
+                                ]
+                            )
+                        }
+                    )
+                ]
+            )
+        }
+    )
+}"#;
+
+    assert_eq!(format!("{:#?}", result), expected);
+}
+
+
+#[test]
+fn it_parses_json_arrays_to_toml() {
+
+    // Example from:
+    // toml-0.2.1/tests/valid/arrays.json
+
+    let text = r#"
+{
+    "ints": {
+        "type": "array",
+        "value": [
+            {"type": "integer", "value": "1"},
+            {"type": "integer", "value": "2"},
+            {"type": "integer", "value": "3"}
+        ]
+    },
+    "floats": {
+        "type": "array",
+        "value": [
+            {"type": "float", "value": "1.1"},
+            {"type": "float", "value": "2.1"},
+            {"type": "float", "value": "3.1"}
+        ]
+    },
+    "strings": {
+        "type": "array",
+        "value": [
+            {"type": "string", "value": "a"},
+            {"type": "string", "value": "b"},
+            {"type": "string", "value": "c"}
+        ]
+    },
+    "dates": {
+        "type": "array",
+        "value": [
+            {"type": "datetime", "value": "1987-07-05T17:45:00Z"},
+            {"type": "datetime", "value": "1979-05-27T07:32:00Z"},
+            {"type": "datetime", "value": "2006-06-01T11:00:00Z"}
+        ]
+    }
+}"#;
+
+    let c: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+    let result = json_object_to_btreemap(&c.as_object().unwrap());
+
+    let expected = r#"{
+    "dates": Table(
+        {
+            "type": String(
+                "array"
+            ),
+            "value": Array(
+                [
+                    Table(
+                        {
+                            "type": String(
+                                "datetime"
+                            ),
+                            "value": String(
+                                "1987-07-05T17:45:00Z"
+                            )
+                        }
+                    ),
+                    Table(
+                        {
+                            "type": String(
+                                "datetime"
+                            ),
+                            "value": String(
+                                "1979-05-27T07:32:00Z"
+                            )
+                        }
+                    ),
+                    Table(
+                        {
+                            "type": String(
+                                "datetime"
+                            ),
+                            "value": String(
+                                "2006-06-01T11:00:00Z"
+                            )
+                        }
+                    )
+                ]
+            )
+        }
+    ),
+    "floats": Table(
+        {
+            "type": String(
+                "array"
+            ),
+            "value": Array(
+                [
+                    Table(
+                        {
+                            "type": String(
+                                "float"
+                            ),
+                            "value": String(
+                                "1.1"
+                            )
+                        }
+                    ),
+                    Table(
+                        {
+                            "type": String(
+                                "float"
+                            ),
+                            "value": String(
+                                "2.1"
+                            )
+                        }
+                    ),
+                    Table(
+                        {
+                            "type": String(
+                                "float"
+                            ),
+                            "value": String(
+                                "3.1"
+                            )
+                        }
+                    )
+                ]
+            )
+        }
+    ),
+    "ints": Table(
+        {
+            "type": String(
+                "array"
+            ),
+            "value": Array(
+                [
+                    Table(
+                        {
+                            "type": String(
+                                "integer"
+                            ),
+                            "value": String(
+                                "1"
+                            )
+                        }
+                    ),
+                    Table(
+                        {
+                            "type": String(
+                                "integer"
+                            ),
+                            "value": String(
+                                "2"
+                            )
+                        }
+                    ),
+                    Table(
+                        {
+                            "type": String(
+                                "integer"
+                            ),
+                            "value": String(
+                                "3"
+                            )
+                        }
+                    )
+                ]
+            )
+        }
+    ),
+    "strings": Table(
+        {
+            "type": String(
+                "array"
+            ),
+            "value": Array(
+                [
+                    Table(
+                        {
+                            "type": String(
+                                "string"
+                            ),
+                            "value": String(
+                                "a"
+                            )
+                        }
+                    ),
+                    Table(
+                        {
+                            "type": String(
+                                "string"
+                            ),
+                            "value": String(
+                                "b"
+                            )
+                        }
+                    ),
+                    Table(
+                        {
+                            "type": String(
+                                "string"
+                            ),
+                            "value": String(
+                                "c"
+                            )
+                        }
+                    )
+                ]
+            )
+        }
+    )
+}"#;
+
+    assert_eq!(format!("{:#?}", result), expected);
 }

--- a/src/book/bookconfig_test.rs
+++ b/src/book/bookconfig_test.rs
@@ -18,19 +18,12 @@ fn it_parses_json_config() {
 
     config.parse_from_json_string(&text.to_string());
 
-    let expected = r#"BookConfig {
-    root: ".",
-    dest: "book",
-    src: "src",
-    theme_path: "theme",
-    title: "mdBook Documentation",
-    author: "Mathieu David",
-    description: "Create book from markdown files. Like Gitbook but implemented in Rust",
-    indent_spaces: 4,
-    multilingual: false
-}"#;
+    let mut expected = BookConfig::new(Path::new("."));
+    expected.title = "mdBook Documentation".to_string();
+    expected.author = "Mathieu David".to_string();
+    expected.description = "Create book from markdown files. Like Gitbook but implemented in Rust".to_string();
 
-    assert_eq!(format!("{:#?}", config), expected);
+    assert_eq!(format!("{:#?}", config), format!("{:#?}", expected));
 }
 
 #[test]
@@ -46,19 +39,12 @@ author = "Mathieu David"
 
     config.parse_from_toml_string(&text.to_string());
 
-    let expected = r#"BookConfig {
-    root: ".",
-    dest: "book",
-    src: "src",
-    theme_path: "theme",
-    title: "mdBook Documentation",
-    author: "Mathieu David",
-    description: "Create book from markdown files. Like Gitbook but implemented in Rust",
-    indent_spaces: 4,
-    multilingual: false
-}"#;
+    let mut expected = BookConfig::new(Path::new("."));
+    expected.title = "mdBook Documentation".to_string();
+    expected.author = "Mathieu David".to_string();
+    expected.description = "Create book from markdown files. Like Gitbook but implemented in Rust".to_string();
 
-    assert_eq!(format!("{:#?}", config), expected);
+    assert_eq!(format!("{:#?}", config), format!("{:#?}", expected));
 }
 
 #[test]

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -1,6 +1,8 @@
 pub mod bookitem;
 pub mod bookconfig;
 
+pub mod bookconfig_test;
+
 pub use self::bookitem::{BookItem, BookItems};
 pub use self::bookconfig::BookConfig;
 

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -1,9 +1,10 @@
 use std::path::Path;
-use std::collections::BTreeMap;
+use std::collections::{VecDeque, BTreeMap};
 
 use serde_json;
 use serde_json::value::ToJson;
 use handlebars::{Handlebars, RenderError, RenderContext, Helper, Context, Renderable};
+
 
 // Handlebars helper for navigation
 
@@ -14,9 +15,9 @@ pub fn previous(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext
     // get value from context data
     // rc.get_path() is current json parent path, you should always use it like this
     // param is the key of value you want to display
-    let chapters = c.navigate(rc.get_path(), "chapters");
+    let chapters = c.navigate(rc.get_path(), &VecDeque::new(), "chapters");
 
-    let current = c.navigate(rc.get_path(), "path")
+    let current = c.navigate(rc.get_path(), &VecDeque::new(), "path")
         .to_string()
         .replace("\"", "");
 
@@ -114,9 +115,9 @@ pub fn next(c: &Context, _h: &Helper, r: &Handlebars, rc: &mut RenderContext) ->
     // get value from context data
     // rc.get_path() is current json parent path, you should always use it like this
     // param is the key of value you want to display
-    let chapters = c.navigate(rc.get_path(), "chapters");
+    let chapters = c.navigate(rc.get_path(), &VecDeque::new(), "chapters");
 
-    let current = c.navigate(rc.get_path(), "path")
+    let current = c.navigate(rc.get_path(), &VecDeque::new(), "path")
         .to_string()
         .replace("\"", "");
 

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::collections::BTreeMap;
+use std::collections::{VecDeque, BTreeMap};
 
 use serde_json;
 use handlebars::{Handlebars, HelperDef, RenderError, RenderContext, Helper, Context};
@@ -15,8 +15,8 @@ impl HelperDef for RenderToc {
         // get value from context data
         // rc.get_path() is current json parent path, you should always use it like this
         // param is the key of value you want to display
-        let chapters = c.navigate(rc.get_path(), "chapters");
-        let current = c.navigate(rc.get_path(), "path").to_string().replace("\"", "");
+        let chapters = c.navigate(rc.get_path(), &VecDeque::new(), "chapters");
+        let current = c.navigate(rc.get_path(), &VecDeque::new(), "path").to_string().replace("\"", "");
         try!(rc.writer.write("<ul class=\"chapter\">".as_bytes()));
 
         // Decode json format


### PR DESCRIPTION
Some work towards #96. It parses the same config as either from `book.toml` or `book.json`.

This can be merged without concern for the larger refactoring.