### PR TITLE
widen hit regions of menu buttons

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -163,7 +163,7 @@ table thead td {
 }
 .menu-bar i {
   position: relative;
-  margin: 0 10px;
+  padding: 0 10px;
   z-index: 10;
   line-height: 50px;
   -webkit-transition: color 0.5s;


### PR DESCRIPTION
Wider hit regions are easier to pick with mouse.

![see here](https://cloud.githubusercontent.com/assets/196601/22856865/19096042-f0a3-11e6-900e-fe9966e32109.png)
