### PR TITLE
Print version: fix up header links

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -138,7 +138,10 @@ impl Renderer for HtmlHandlebars {
 
         // Render the handlebars template with the data
         debug!("[*]: Render template");
+
         let rendered = try!(handlebars.render("index", &data));
+        let rendered = build_header_links(rendered);
+
         try!(book.write_file(Path::new("print").with_extension("html"), &rendered.into_bytes()));
         info!("[*] Creating print.html ✓");
 


### PR DESCRIPTION
This got left out of https://github.com/azerupi/mdBook/pull/207

It'd be nice if we could get a point release with this in it for https://github.com/rust-lang/rust/pull/39976

This should be the last change like this 😄 