### PR TITLE
Implement playpen support for ```rust

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -307,7 +307,9 @@ fn add_playpen_pre(html: String) -> String {
                 format!("<pre class=\"playpen\">{}</pre>", text)
             } else {
                 // we need to inject our own main
-                format!("<pre class=\"playpen\"><code class=\"{}\">#fn main() {{
+                format!("<pre class=\"playpen\"><code class=\"{}\"># #![allow(unused_variables)]
+# 
+#fn main() {{
 {}
 #}}</code></pre>", classes, code)
             }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -294,14 +294,23 @@ fn fix_code_blocks(html: String) -> String {
 }
 
 fn add_playpen_pre(html: String) -> String {
-    let regex = Regex::new(r##"((?s)<code[^>]?class="([^"]+)".*?>.*?</code>)"##).unwrap();
+    let regex = Regex::new(r##"((?s)<code[^>]?class="([^"]+)".*?>(.*?)</code>)"##).unwrap();
     regex.replace_all(&html, |caps: &Captures| {
         let text = &caps[1];
         let classes = &caps[2];
+        let code = &caps[3];
 
         if classes.contains("language-rust") && !classes.contains("ignore") {
             // wrap the contents in an external pre block
-            format!("<pre class=\"playpen\">{}</pre>", text)
+
+            if text.contains("fn main") {
+                format!("<pre class=\"playpen\">{}</pre>", text)
+            } else {
+                // we need to inject our own main
+                format!("<pre class=\"playpen\"><code class=\"{}\">#fn main() {{
+{}
+#}}</code></pre>", classes, code)
+            }
         } else {
             // not language-rust, so no-op
             format!("{}", text)


### PR DESCRIPTION
Fixes #29 

So, this all works, and fixes an important regression in mdbook for the rust book.

However.

The big issue remaining is the "wrap in `main`" rules from rustdoc. In other words, something like this:

    ```rust
    let x = 5;
    ```

will fail, as it needs to be inside of `main`.

I'm not sure what the right way is to go here, exactly. I'm imagining duplicating the logic of rustdoc here makes sense.

Thoughts @azerupi @carols10cents @frewsxcv ?