### PR TITLE
add a .gitattributes to ensure proper line ending settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+[attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
+
+* text=auto eol=lf
+*.rs rust


### PR DESCRIPTION
This should prevent stuff like https://github.com/azerupi/mdBook/issues/234 even for people who don't have git configured properly.