### PR TITLE
Accept nightly examples.

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -318,15 +318,37 @@ fn add_playpen_pre(html: String) -> String {
                 format!("<pre class=\"playpen\">{}</pre>", text)
             } else {
                 // we need to inject our own main
+                let (attrs, code) = partition_source(code);
                 format!("<pre class=\"playpen\"><code class=\"{}\"># #![allow(unused_variables)]
-# 
-#fn main() {{
+{}#fn main() {{
 {}
-#}}</code></pre>", classes, code)
+#}}</code></pre>", classes, attrs, code)
             }
         } else {
             // not language-rust, so no-op
             format!("{}", text)
         }
     }).into_owned()
+}
+
+fn partition_source(s: &str) -> (String, String) {
+    let mut after_header = false;
+    let mut before = String::new();
+    let mut after = String::new();
+
+    for line in s.lines() {
+        let trimline = line.trim();
+        let header = trimline.chars().all(|c| c.is_whitespace()) ||
+            trimline.starts_with("#![");
+        if !header || after_header {
+            after_header = true;
+            after.push_str(line);
+            after.push_str("\n");
+        } else {
+            before.push_str(line);
+            before.push_str("\n");
+        }
+    }
+
+    (before, after)
 }

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -208,6 +208,18 @@ function run_rust_code(code_block) {
         result_block = code_block.find(".result");
     }
 
+    let text = code_block.find(".language-rust").text();
+
+    let params = {
+        version: "stable",
+        optimize: "0",
+        code: text,
+    };
+
+    if(text.includes("#![feature")) {
+        params.version = "nightly";
+    }
+
     result_block.text("Running...");
 
     $.ajax({
@@ -216,7 +228,7 @@ function run_rust_code(code_block) {
         crossDomain: true,
         dataType: "json",
         contentType: "application/json",
-        data: JSON.stringify({version: "stable", optimize: "0", code: code_block.find(".language-rust").text() }),
+        data: JSON.stringify(params),
         success: function(response){
             result_block.text(response.result);
         }


### PR DESCRIPTION
This also brings us to parity with rustdoc regarding attributes in
general; while this PR was focused on enabling nightly, that was a
happy accident.

Fixes #241 

Check it out:

<img width="566" alt="mdbook" src="https://cloud.githubusercontent.com/assets/27786/24569510/796c78e6-1634-11e7-8900-5a1b20eb8846.png">

This is after clicking "run" on each. Top goes to stable, bottom to nightly.