### PR TITLE
Added monospace font with support for box-drawing chars

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -3,6 +3,10 @@ body {
   font-family: "Open Sans", sans-serif;
   color: #333;
 }
+code {
+  font-family: "Source Code Pro", "Menlo", "DejaVu Sans Mono", monospace;
+  font-size: 0.875em;
+}
 .left {
   float: left;
 }

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -10,7 +10,8 @@
         <base href="{{ path_to_root }}">
 
         <link rel="stylesheet" href="book.css">
-        <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
+        <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500" rel="stylesheet" type="text/css">
 
         <link rel="shortcut icon" href="{{ favicon }}">
 

--- a/src/theme/stylus/general.styl
+++ b/src/theme/stylus/general.styl
@@ -3,6 +3,11 @@ html, body {
     color: #333
 }
 
+code {
+    font-family: "Source Code Pro", "Menlo", "DejaVu Sans Mono", monospace;
+    font-size: 0.875em;
+}
+
 .left {
     float: left
 }


### PR DESCRIPTION
Even Github seams to not be capable of properly showing curses-style box-drawing characters:

```
  ╭────────────────────╮
╭→│ boxes are awesome! ├─╮
│ ╰────────────────────╯ │
╰────────────────────────╯
```

With this PR mdBook would be (`$ cargo doc` does support them, too!).