### PR TITLE
Remove the extra run button on runnable rust files

### DIFF
--- a/src/renderer/html_handlebars/helpers/playpen.rs
+++ b/src/renderer/html_handlebars/helpers/playpen.rs
@@ -35,7 +35,7 @@ pub fn render_playpen(s: &str, path: &Path) -> String {
             continue;
         };
 
-        let replacement = String::new() + "<pre class=\"playpen\"><code class=\"language-rust\">" + &file_content +
+        let replacement = String::new() + "<pre><code class=\"language-rust\">" + &file_content +
                           "</code></pre>";
 
         replaced.push_str(&s[previous_end_index..playpen.start_index]);


### PR DESCRIPTION
The playpen helper now uses a simple pre block instead of a pre block
with class playpen as it led to nested playpens.

Fixes #251.