### PR TITLE
Implement basic collapsible sidebar items

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -40,6 +40,9 @@ table td {
 table thead td {
   font-weight: 700;
 }
+details > summary {
+  outline: none;
+}
 .sidebar {
   position: absolute;
   left: 0;

--- a/src/theme/stylus/general.styl
+++ b/src/theme/stylus/general.styl
@@ -38,3 +38,7 @@ table {
       td { font-weight: 700; }
     }
 }
+
+details > summary {
+    outline: none;
+}


### PR DESCRIPTION
A very basic attempt at fixing https://github.com/azerupi/mdBook/issues/25.

Currently the disclosure state is not persisted across page-loads for the items. I'm not sure if one would even want such a persistent behavior to begin with.

- [x] Basic collapsible HTML lists
- [ ] (Persistent state across page loads?)
- [ ] Config option
- [ ] Documentation

What would be the desired functionality/behavior of this feature?