### PR TITLE
Change MathJax to use CDNJS

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -22,7 +22,7 @@
         <link rel="stylesheet" href="tomorrow-night.css">
 
         <!-- MathJax -->
-        <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
         <!-- Fetch JQuery from CDN but have a local fallback -->
         <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>


### PR DESCRIPTION
Because the [MathJax CDN will soon be retired](https://www.mathjax.org/cdn-shutting-down/).