### PR TITLE
Support for Google Analytics

### DIFF
--- a/src/book/bookconfig.rs
+++ b/src/book/bookconfig.rs
@@ -21,6 +21,7 @@ pub struct BookConfig {
 
     pub indent_spaces: i32,
     multilingual: bool,
+    pub google_analytics: Option<String>,
 }
 
 impl BookConfig {
@@ -37,6 +38,7 @@ impl BookConfig {
 
             indent_spaces: 4, // indentation used for SUMMARY.md
             multilingual: false,
+            google_analytics: None,
         }
     }
 
@@ -152,6 +154,11 @@ impl BookConfig {
                 theme_path = self.get_root().join(&theme_path);
             }
             self.set_theme_path(&theme_path);
+        }
+
+        // Google analytics code
+        if let Some(id) = config.get("google_analytics_id") {
+            self.google_analytics = Some(id.to_string().replace("\"", ""));
         }
 
         self

--- a/src/book/bookconfig_test.rs
+++ b/src/book/bookconfig_test.rs
@@ -347,3 +347,25 @@ fn it_parses_json_arrays_to_toml() {
 
     assert_eq!(format!("{:#?}", result), expected);
 }
+
+#[test]
+fn it_fetches_google_analytics_from_toml() {
+    let text = r#"
+title = "mdBook Documentation"
+description = "Create book from markdown files. Like Gitbook but implemented in Rust"
+author = "Mathieu David"
+google_analytics_id = "123456"
+"#;
+
+    let mut config = BookConfig::new(Path::new("."));
+
+    config.parse_from_toml_string(&text.to_string());
+
+    let mut expected = BookConfig::new(Path::new("."));
+    expected.title = "mdBook Documentation".to_string();
+    expected.author = "Mathieu David".to_string();
+    expected.description = "Create book from markdown files. Like Gitbook but implemented in Rust".to_string();
+    expected.google_analytics = Some("123456".to_string());
+
+    assert_eq!(format!("{:#?}", config), format!("{:#?}", expected));
+}

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -36,6 +36,8 @@ pub struct MDBook {
     /// Should `mdbook build` create files referenced from SUMMARY.md if they
     /// don't exist
     pub create_missing: bool,
+
+    pub google_analytics: Option<String>,
 }
 
 impl MDBook {
@@ -84,6 +86,7 @@ impl MDBook {
 
             livereload: None,
             create_missing: true,
+            google_analytics: None,
         }
     }
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -194,7 +194,9 @@ fn make_data(book: &MDBook) -> Result<serde_json::Map<String, serde_json::Value>
     }
 
     // Add google analytics tag
-    data.insert("google_analytics".to_owned(), json!("INSERT_GA_ID_HERE"));
+    if let Some(ref ga) = book.google_analytics {
+        data.insert("google_analytics".to_owned(), json!(ga));
+    }
 
     let mut chapters = vec![];
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -193,6 +193,9 @@ fn make_data(book: &MDBook) -> Result<serde_json::Map<String, serde_json::Value>
         data.insert("livereload".to_owned(), json!(livereload));
     }
 
+    // Add google analytics tag
+    data.insert("google_analytics".to_owned(), json!("INSERT_GA_ID_HERE"));
+
     let mut chapters = vec![];
 
     for item in book.iter() {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -111,6 +111,19 @@
         <!-- Livereload script (if served using the cli tool) -->
         {{{livereload}}}
 
+        {{#if google_analytics}}
+        <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '{{google_analytics}}', 'auto');
+        ga('send', 'pageview');
+        </script>
+      {{/if}}
+
+
         <script src="highlight.js"></script>
         <script src="book.js"></script>
     </body>


### PR DESCRIPTION
I've added support for including google analytics in your rendered book. You simply need to add the `google_analytics_id` key to your `book.toml` and that should be enough to tell `mdbook` to insert the usual snippet at the bottom of each page.

(fixes #268)