### PR TITLE
Do not add playpen boilerplate when using quick_main!

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -319,7 +319,7 @@ fn add_playpen_pre(html: String) -> String {
         if classes.contains("language-rust") && !classes.contains("ignore") {
             // wrap the contents in an external pre block
 
-            if text.contains("fn main") {
+            if text.contains("fn main") || text.contains("quick_main!") {
                 format!("<pre class=\"playpen\">{}</pre>", text)
             } else {
                 // we need to inject our own main


### PR DESCRIPTION
Code snippets using quick_main! macro from error-chain
https://docs.rs/error-chain/0.10.0/error_chain/macro.quick_main.html
no longer have `fn main` implicitly added

resolves https://github.com/azerupi/mdBook/issues/282