### PR TITLE
Fix indentation of hidden code blocks

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -146,10 +146,10 @@ $( document ).ready(function() {
         for(var n = 0; n < lines.length; n++){
             if($.trim(lines[n])[0] == hiding_character){
                 if(first_non_hidden_line){
-                    lines[n] = "<span class=\"hidden\">" + "\n" + lines[n].replace(/(\s*)#/, "$1") + "</span>";
+                    lines[n] = "<span class=\"hidden\">" + "\n" + lines[n].replace(/(\s*)# ?/, "$1") + "</span>";
                 }
                 else {
-                    lines[n] = "<span class=\"hidden\">" + lines[n].replace(/(\s*)#/, "$1") + "\n"  +  "</span>";
+                    lines[n] = "<span class=\"hidden\">" + lines[n].replace(/(\s*)# ?/, "$1") + "\n"  +  "</span>";
                 }
                 lines_hidden = true;
             }


### PR DESCRIPTION
Hidden code blocks are no longer indented with
one additional space (required for doctests to compile in some cases)
Now the behavior is similar to the rustdoc's

Please note that I have zero experience with js so I am really open to criticism here ;)

resolves https://github.com/azerupi/mdBook/issues/281