### PR TITLE
Reformatted "Serving on " message for easier consumption

### DIFF
--- a/src/bin/mdbook.rs
+++ b/src/bin/mdbook.rs
@@ -270,10 +270,11 @@ fn serve(args: &ArgMatches) -> Result<(), Box<Error>> {
 
     std::thread::spawn(move || { ws_server.listen(&*ws_address).unwrap(); });
 
-    println!("\nServing on {}", address);
+    let serving_url = format!("http://{}", address);
+    println!("\nServing on: {}", serving_url);
 
     if open_browser {
-        open(format!("http://{}", address));
+        open(serving_url);
     }
 
     trigger_on_change(&mut book, move |path, book| {


### PR DESCRIPTION
Now we have: `Serving on: http://localhost:3000`

I am aware of the `-o` option but it has been raised as desirable to be able to just copy and paste the address from terminal.

fixes: https://github.com/azerupi/mdBook/issues/299