### PR TITLE
Now changes to `theme` directory trigger rebuild for `mdbook serve`

### DIFF
--- a/book-example/src/format/theme/theme.md
+++ b/book-example/src/format/theme/theme.md
@@ -4,7 +4,7 @@ The default renderer uses a [handlebars](http://handlebarsjs.com/) template to r
 included in the mdBook binary.
 
 The theme is totally customizable, you can selectively replace every file from the theme by your own by adding a
-`theme` directory in your source folder. Create a new file with the name of the file you want to override
+`theme` directory next to `src` folder in your project root. Create a new file with the name of the file you want to override
 and now that file will be used instead of the default file.
 
 Here are the files you can override:

--- a/src/bin/mdbook.rs
+++ b/src/bin/mdbook.rs
@@ -346,6 +346,9 @@ fn trigger_on_change<F>(book: &mut MDBook, closure: F) -> ()
         ::std::process::exit(0);
     };
 
+    // Add the theme directory to the watcher
+    watcher.watch(book.get_theme_path(), Recursive).unwrap_or_default();
+
     // Add the book.{json,toml} file to the watcher if it exists, because it's not
     // located in the source directory
     if watcher


### PR DESCRIPTION
As `theme` dir is no longer under `src`. Updates to "theme" did not
trigger book rebuild.
Also fixed misleading docs about `theme` dir being located in `src`

fixes https://github.com/azerupi/mdBook/issues/306