### PR TITLE
Minor cleanup

### DIFF
--- a/book-example/src/lib/lib.md
+++ b/book-example/src/lib/lib.md
@@ -9,13 +9,15 @@ extern crate mdbook;
 use mdbook::MDBook;
 use std::path::Path;
 
+# #[allow(unused_variables)]
 fn main() {
-    let mut book =  MDBook::new(Path::new("my-book"))   // Path to root
-                        .set_src(Path::new("src"))      // Path from root to source directory
-                        .set_dest(Path::new("book"))    // Path from root to output directory
-                        .read_config();                 // Parse book.toml or book.json file for configuration
+    let mut book =  MDBook::new("my-book")        // Path to root
+                        .with_source("src")       // Path from root to source directory
+                        .with_destination("book") // Path from root to output directory
+                        .read_config()            // Parse book.toml or book.json configuration file
+                        .expect("I don't handle configuration file error, but you should!");
 
-    book.build().unwrap();                              // Render the book
+    book.build().unwrap();                        // Render the book
 }
 ```
 

--- a/src/bin/mdbook.rs
+++ b/src/bin/mdbook.rs
@@ -173,7 +173,7 @@ fn build(args: &ArgMatches) -> Result<(), Box<Error>> {
     let book = MDBook::new(&book_dir).read_config()?;
 
     let mut book = match args.value_of("dest-dir") {
-        Some(dest_dir) => book.with_destination(Path::new(dest_dir)),
+        Some(dest_dir) => book.with_destination(dest_dir),
         None => book,
     };
 
@@ -200,7 +200,7 @@ fn watch(args: &ArgMatches) -> Result<(), Box<Error>> {
     let book = MDBook::new(&book_dir).read_config()?;
 
     let mut book = match args.value_of("dest-dir") {
-        Some(dest_dir) => book.with_destination(Path::new(dest_dir)),
+        Some(dest_dir) => book.with_destination(dest_dir),
         None => book,
     };
 
@@ -232,7 +232,7 @@ fn serve(args: &ArgMatches) -> Result<(), Box<Error>> {
     let book = MDBook::new(&book_dir).read_config()?;
 
     let mut book = match args.value_of("dest-dir") {
-        Some(dest_dir) => book.with_destination(Path::new(dest_dir)),
+        Some(dest_dir) => book.with_destination(dest_dir),
         None => book,
     };
 

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -39,9 +39,9 @@ impl MDBook {
     /// ```no_run
     /// # extern crate mdbook;
     /// # use mdbook::MDBook;
-    /// # use std::path::Path;
+    /// # #[allow(unused_variables)]
     /// # fn main() {
-    /// let book = MDBook::new(Path::new("root_dir"));
+    /// let book = MDBook::new("root_dir");
     /// # }
     /// ```
     ///
@@ -59,8 +59,9 @@ impl MDBook {
     /// They can both be changed by using [`set_src()`](#method.set_src) and
     /// [`set_dest()`](#method.set_dest)
 
-    pub fn new(root: &Path) -> MDBook {
+    pub fn new<P: Into<PathBuf>>(root: P) -> MDBook {
 
+        let root = root.into();
         if !root.exists() || !root.is_dir() {
             warn!("{:?} No directory with that name", root);
         }
@@ -84,9 +85,9 @@ impl MDBook {
     /// # extern crate mdbook;
     /// # use mdbook::MDBook;
     /// # use mdbook::BookItem;
-    /// # use std::path::Path;
+    /// # #[allow(unused_variables)]
     /// # fn main() {
-    /// # let mut book = MDBook::new(Path::new("mybook"));
+    /// # let book = MDBook::new("mybook");
     /// for item in book.iter() {
     ///     match item {
     ///         &BookItem::Chapter(ref section, ref chapter) => {},
@@ -347,10 +348,10 @@ impl MDBook {
     /// extern crate mdbook;
     /// use mdbook::MDBook;
     /// use mdbook::renderer::HtmlHandlebars;
-    /// # use std::path::Path;
     ///
+    /// # #[allow(unused_variables)]
     /// fn main() {
-    ///     let mut book = MDBook::new(Path::new("mybook"))
+    ///     let book = MDBook::new("mybook")
     ///                         .set_renderer(Box::new(HtmlHandlebars::new()));
     ///
     /// // In this example we replace the default renderer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,16 +21,16 @@
 //! extern crate mdbook;
 //!
 //! use mdbook::MDBook;
-//! use std::path::Path;
 //!
+//! # #[allow(unused_variables)]
 //! fn main() {
-//!     let mut book =  MDBook::new(Path::new("my-book"))           // Path to root
-//!                         .with_source(Path::new("src"))          // Path from root to source directory
-//!                         .with_destination(Path::new("book"))    // Path from root to output directory
-//!                         .read_config()                          // Parse book.json file for configuration
-//!                         .expect("I don't handle the error for the configuration file, but you should!");
+//!     let mut book =  MDBook::new("my-book")        // Path to root
+//!                         .with_source("src")       // Path from root to source directory
+//!                         .with_destination("book") // Path from root to output directory
+//!                         .read_config()            // Parse book.toml configuration file
+//!                         .expect("I don't handle configuration file error, but you should!");
 //!
-//!     book.build().unwrap();                                      // Render the book
+//!     book.build().unwrap();                        // Render the book
 //! }
 //! ```
 //!
@@ -46,12 +46,12 @@
 //! #
 //! # use mdbook::MDBook;
 //! # use mdbook::renderer::HtmlHandlebars;
-//! # use std::path::Path;
 //! #
+//! # #[allow(unused_variables)]
 //! # fn main() {
 //! #   let your_renderer = HtmlHandlebars::new();
 //! #
-//!     let book =  MDBook::new(Path::new("my-book")).set_renderer(Box::new(your_renderer));
+//!     let book =  MDBook::new("my-book").set_renderer(Box::new(your_renderer));
 //! # }
 //! ```
 //! If you make a renderer, you get the book constructed in form of `Vec<BookItems>` and you get
@@ -61,12 +61,11 @@
 //!
 //! ## utils
 //!
-//! I have regrouped some useful functions in the [utils](utils/index.html) module, like the following function
+//! I have regrouped some useful functions in the [utils](utils/index.html) module, like the
+//! following function [`utils::fs::create_file(path:
+//! &Path)`](utils/fs/fn.create_file.html)
 //!
-//! ```ignore
-//! utils::fs::create_path(path: &Path)
-//! ```
-//! This function creates all the directories in a given path if they do not exist
+//! This function creates a file and returns it. But before creating the file it checks every directory in the path to see if it exists, and if it does not it will be created.
 //!
 //! Make sure to take a look at it.
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -152,7 +152,7 @@ impl Renderer for HtmlHandlebars {
         // Update the context with data for this file
         data.insert("path".to_owned(), json!("print.md"));
         data.insert("content".to_owned(), json!(print_content));
-        data.insert("path_to_root".to_owned(), json!(utils::fs::path_to_root(Path::new("print.md"))));
+        data.insert("path_to_root".to_owned(), json!(utils::fs::path_to_root("print.md")));
 
         // Render the handlebars template with the data
         debug!("[*]: Render template");

--- a/src/renderer/html_handlebars/helpers/playpen.rs
+++ b/src/renderer/html_handlebars/helpers/playpen.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Read;
 
 
-pub fn render_playpen(s: &str, path: &Path) -> String {
+pub fn render_playpen<P: AsRef<Path>>(s: &str, path: P) -> String {
     // When replacing one thing in a string by something with a different length,
     // the indices after that will not correspond,
     // we therefore have to store the difference to correct this
@@ -60,7 +60,8 @@ struct Playpen {
     escaped: bool,
 }
 
-fn find_playpens(s: &str, base_path: &Path) -> Vec<Playpen> {
+fn find_playpens<P: AsRef<Path>>(s: &str, base_path: P) -> Vec<Playpen> {
+    let base_path = base_path.as_ref();
     let mut playpens = vec![];
     for (i, _) in s.match_indices("{{#playpen") {
         debug!("[*]: find_playpen");
@@ -122,28 +123,28 @@ fn find_playpens(s: &str, base_path: &Path) -> Vec<Playpen> {
 #[test]
 fn test_find_playpens_no_playpen() {
     let s = "Some random text without playpen...";
-    assert!(find_playpens(s, Path::new("")) == vec![]);
+    assert!(find_playpens(s, "") == vec![]);
 }
 
 #[test]
 fn test_find_playpens_partial_playpen() {
     let s = "Some random text with {{#playpen...";
-    assert!(find_playpens(s, Path::new("")) == vec![]);
+    assert!(find_playpens(s, "") == vec![]);
 }
 
 #[test]
 fn test_find_playpens_empty_playpen() {
     let s = "Some random text with {{#playpen}} and {{#playpen   }}...";
-    assert!(find_playpens(s, Path::new("")) == vec![]);
+    assert!(find_playpens(s, "") == vec![]);
 }
 
 #[test]
 fn test_find_playpens_simple_playpen() {
     let s = "Some random text with {{#playpen file.rs}} and {{#playpen test.rs }}...";
 
-    println!("\nOUTPUT: {:?}\n", find_playpens(s, Path::new("")));
+    println!("\nOUTPUT: {:?}\n", find_playpens(s, ""));
 
-    assert!(find_playpens(s, Path::new("")) ==
+    assert!(find_playpens(s, "") ==
             vec![Playpen {
                      start_index: 22,
                      end_index: 42,
@@ -164,9 +165,9 @@ fn test_find_playpens_simple_playpen() {
 fn test_find_playpens_complex_playpen() {
     let s = "Some random text with {{#playpen file.rs editable}} and {{#playpen test.rs editable }}...";
 
-    println!("\nOUTPUT: {:?}\n", find_playpens(s, Path::new("dir")));
+    println!("\nOUTPUT: {:?}\n", find_playpens(s, "dir"));
 
-    assert!(find_playpens(s, Path::new("dir")) ==
+    assert!(find_playpens(s, "dir") ==
             vec![Playpen {
                      start_index: 22,
                      end_index: 51,
@@ -187,9 +188,9 @@ fn test_find_playpens_complex_playpen() {
 fn test_find_playpens_escaped_playpen() {
     let s = "Some random text with escaped playpen \\{{#playpen file.rs editable}} ...";
 
-    println!("\nOUTPUT: {:?}\n", find_playpens(s, Path::new("")));
+    println!("\nOUTPUT: {:?}\n", find_playpens(s, ""));
 
-    assert!(find_playpens(s, Path::new("")) ==
+    assert!(find_playpens(s, "") ==
             vec![Playpen {
                      start_index: 39,
                      end_index: 68,

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, Component};
+use std::path::{Path, PathBuf, Component};
 use std::error::Error;
 use std::io::{self, Read};
 use std::fs::{self, File};
@@ -30,16 +30,16 @@ pub fn file_to_string(path: &Path) -> Result<String, Box<Error>> {
 /// This is mostly interesting for a relative path to point back to the
 /// directory from where the path starts.
 ///
-/// ```ignore
-/// let mut path = Path::new("some/relative/path");
-///
-/// println!("{}", path_to_root(&path));
-/// ```
-///
-/// **Outputs**
-///
-/// ```text
-/// "../../"
+/// ```rust
+/// # extern crate mdbook;
+/// #
+/// # use std::path::Path;
+/// # use mdbook::utils::fs::path_to_root;
+/// #
+/// # fn main() {
+/// let path = Path::new("some/relative/path");
+/// assert_eq!(path_to_root(path), "../../");
+/// # }
 /// ```
 ///
 /// **note:** it's not very fool-proof, if you find a situation where
@@ -47,11 +47,11 @@ pub fn file_to_string(path: &Path) -> Result<String, Box<Error>> {
 /// Consider [submitting a new issue](https://github.com/azerupi/mdBook/issues)
 /// or a [pull-request](https://github.com/azerupi/mdBook/pulls) to improve it.
 
-pub fn path_to_root(path: &Path) -> String {
+pub fn path_to_root<P: Into<PathBuf>>(path: P) -> String {
     debug!("[fn]: path_to_root");
     // Remove filename and add "../" for every directory
 
-    path.to_path_buf()
+    path.into()
         .parent()
         .expect("")
         .components()

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,7 +1,6 @@
 extern crate mdbook;
 extern crate tempdir;
 
-use std::path::Path;
 use std::fs::File;
 use std::io::Write;
 
@@ -13,10 +12,10 @@ use tempdir::TempDir;
 #[test]
 fn do_not_overwrite_unspecified_config_values() {
     let dir = TempDir::new("mdbook").expect("Could not create a temp dir");
-    
+
     let book = MDBook::new(dir.path())
-        .with_source(Path::new("bar"))
-        .with_destination(Path::new("baz"));
+        .with_source("bar")
+        .with_destination("baz");
 
     assert_eq!(book.get_root(), dir.path());
     assert_eq!(book.get_source(), dir.path().join("bar"));


### PR DESCRIPTION
- removing need to explicitly use `Path::new` all over the place
- removed warnings from doctests (normally invisible unless `cargo test -- --nocapture`)
- no doctests are norun/ignore now
- updated docs both in book-example and in docs not to refer to nonexisting API's

This is mostly due to my fear of introducing any regressions / warnings to the code when I try to contribute something. 