### PR TITLE
Fixes missing the default "theme" dir location

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -13,7 +13,7 @@ use std::process::Command;
 use {theme, parse, utils};
 use renderer::{Renderer, HtmlHandlebars};
 
-use config::{BookConfig, HtmlConfig};
+use config::BookConfig;
 use config::tomlconfig::TomlConfig;
 use config::jsonconfig::JsonConfig;
 
@@ -262,8 +262,9 @@ impl MDBook {
     pub fn copy_theme(&self) -> Result<(), Box<Error>> {
         debug!("[fn]: copy_theme");
 
-        if let Some(themedir) = self.config.get_html_config().and_then(HtmlConfig::get_theme) {
+        if let Some(htmlconfig) = self.config.get_html_config() {
 
+            let themedir = htmlconfig.get_theme();
             if !themedir.exists() {
                 debug!("[*]: {:?} does not exist, trying to create directory", themedir);
                 fs::create_dir(&themedir)?;
@@ -472,9 +473,9 @@ impl MDBook {
         self
     }
 
-    pub fn get_theme_path(&self) -> Option<&PathBuf> {
+    pub fn get_theme_path(&self) -> Option<&Path> {
         if let Some(htmlconfig) = self.config.get_html_config() {
-            return htmlconfig.get_theme();
+            return Some(htmlconfig.get_theme());
         }
 
         None

--- a/src/config/htmlconfig.rs
+++ b/src/config/htmlconfig.rs
@@ -5,7 +5,7 @@ use super::tomlconfig::TomlHtmlConfig;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HtmlConfig {
     destination: PathBuf,
-    theme: Option<PathBuf>,
+    theme: PathBuf,
     curly_quotes: bool,
     google_analytics: Option<String>,
     additional_css: Vec<PathBuf>,
@@ -25,9 +25,10 @@ impl HtmlConfig {
     /// assert_eq!(config.get_destination(), &output);
     /// ```
     pub fn new<T: Into<PathBuf>>(root: T) -> Self {
+        let root = root.into();
         HtmlConfig {
-            destination: root.into().join("book"),
-            theme: None,
+            destination: root.clone().join("book"),
+            theme: root.join("theme"),
             curly_quotes: false,
             google_analytics: None,
             additional_css: Vec::new(),
@@ -48,9 +49,9 @@ impl HtmlConfig {
 
         if let Some(t) = tomlconfig.theme {
             if t.is_relative() {
-                self.theme = Some(root.join(t));
+                self.theme = root.join(t);
             } else {
-                self.theme = Some(t);
+                self.theme = t;
             }
         }
 
@@ -100,17 +101,16 @@ impl HtmlConfig {
         &self.destination
     }
 
-    // FIXME: How to get a `Option<&Path>` ?
-    pub fn get_theme(&self) -> Option<&PathBuf> {
-        self.theme.as_ref()
+    pub fn get_theme(&self) -> &Path {
+        &self.theme
     }
 
     pub fn set_theme<T: Into<PathBuf>>(&mut self, root: T, theme: T) -> &mut Self {
         let d = theme.into();
         if d.is_relative() {
-            self.theme = Some(root.into().join(d));
+            self.theme = root.into().join(d);
         } else {
-            self.theme = Some(d);
+            self.theme = d;
         }
 
         self

--- a/src/config/htmlconfig.rs
+++ b/src/config/htmlconfig.rs
@@ -40,19 +40,11 @@ impl HtmlConfig {
         let root = root.into();
 
         if let Some(d) = tomlconfig.destination {
-            if d.is_relative() {
-                self.destination = root.join(d);
-            } else {
-                self.destination = d;
-            }
+            self.set_destination(&root, &d);
         }
 
         if let Some(t) = tomlconfig.theme {
-            if t.is_relative() {
-                self.theme = root.join(t);
-            } else {
-                self.theme = t;
-            }
+            self.set_theme(&root, &t);
         }
 
         if let Some(curly_quotes) = tomlconfig.curly_quotes {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 use std::fs::File;
 use std::io::Read;
 
@@ -46,7 +46,7 @@ pub struct Theme {
 }
 
 impl Theme {
-    pub fn new(src: Option<&PathBuf>) -> Self {
+    pub fn new(src: Option<&Path>) -> Self {
 
         // Default theme
         let mut theme = Theme {

--- a/tests/jsonconfig.rs
+++ b/tests/jsonconfig.rs
@@ -83,5 +83,5 @@ fn from_json_output_html_theme() {
 
     let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
 
-    assert_eq!(htmlconfig.get_theme().expect("the theme key was provided"), &PathBuf::from("root/theme"));
+    assert_eq!(htmlconfig.get_theme(), &PathBuf::from("root/theme"));
 }

--- a/tests/tomlconfig.rs
+++ b/tests/tomlconfig.rs
@@ -84,7 +84,7 @@ fn from_toml_output_html_theme() {
 
     let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
 
-    assert_eq!(htmlconfig.get_theme().expect("the theme key was provided"), &PathBuf::from("root/theme"));
+    assert_eq!(htmlconfig.get_theme(), &PathBuf::from("root/theme"));
 }
 
 // Tests that the `output.html.curly-quotes` key is correctly parsed in the TOML config


### PR DESCRIPTION
 if one is not specified in book.toml

fixes https://github.com/azerupi/mdBook/issues/313