### PR TITLE
Hide sidebar on link selection when it occupies large space

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -51,30 +51,20 @@ $( document ).ready(function() {
     });
 
     // Interesting DOM Elements
-    var html = $("html");
     var sidebar = $("#sidebar");
     var page_wrapper = $("#page-wrapper");
     var content = $("#content");
 
     // Toggle sidebar
-    $("#sidebar-toggle").click(function(event){
-        if ( html.hasClass("sidebar-hidden") ) {
-            html.removeClass("sidebar-hidden").addClass("sidebar-visible");
-            localStorage.setItem('sidebar', 'visible');
-        } else if ( html.hasClass("sidebar-visible") ) {
-            html.removeClass("sidebar-visible").addClass("sidebar-hidden");
-            localStorage.setItem('sidebar', 'hidden');
-        } else {
-            if(sidebar.position().left === 0){
-                html.addClass("sidebar-hidden");
-                localStorage.setItem('sidebar', 'hidden');
-            } else {
-                html.addClass("sidebar-visible");
-                localStorage.setItem('sidebar', 'visible');
-            }
+    $("#sidebar-toggle").click(sidebarToggle);
+
+    // Hide sidebar on section link click if it occupies large space
+    // in relation to the whole screen (phone in portrait)
+    $("#sidebar a").click(function(event){
+        if (sidebar.width() > window.screen.width * 0.4) {
+            sidebarToggle();
         }
     });
-
 
     // Scroll sidebar to current active section
     var activeSection = sidebar.find(".active");
@@ -225,6 +215,25 @@ function hideTooltip(elem) {
 function showTooltip(elem, msg) {
     elem.firstChild.innerText=msg;
     elem.setAttribute('class', 'fa fa-copy tooltipped');
+}
+
+function sidebarToggle() {
+    var html = $("html");
+    if ( html.hasClass("sidebar-hidden") ) {
+        html.removeClass("sidebar-hidden").addClass("sidebar-visible");
+        localStorage.setItem('sidebar', 'visible');
+    } else if ( html.hasClass("sidebar-visible") ) {
+        html.removeClass("sidebar-visible").addClass("sidebar-hidden");
+        localStorage.setItem('sidebar', 'hidden');
+    } else {
+        if($("#sidebar").position().left === 0){
+            html.addClass("sidebar-hidden");
+            localStorage.setItem('sidebar', 'hidden');
+        } else {
+            html.addClass("sidebar-visible");
+            localStorage.setItem('sidebar', 'visible');
+        }
+    }
 }
 
 function run_rust_code(code_block) {


### PR DESCRIPTION
Hide sidebar on sidebar link link selection when sidebar occupies large space in relation to the whole screen width (solves problems on phones)

Calculates if sidebar width is large (> 0.4 * screen width) and if yes closes the sidebar.
This intentionally leaves the old behavior on tablets or in landscape mode if there  is enough space on screen.

Originally wanted to use css in conjunction with js but ended up with js only solution.

fixes https://github.com/azerupi/mdBook/issues/125
fixes https://github.com/azerupi/mdBook/issues/318