### PR TITLE
Fix ES5 compatibility.

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -234,9 +234,9 @@ function run_rust_code(code_block) {
         result_block = code_block.find(".result");
     }
 
-    let text = code_block.find(".language-rust").text();
+    var text = code_block.find(".language-rust").text();
 
-    let params = {
+    var params = {
         version: "stable",
         optimize: "0",
         code: text,


### PR DESCRIPTION
Currently book.js contains pure ES5 code, so it is not a big deal to backport just two lines to make old browsers happy.

Thanks!