### PR TITLE
One more ES5 fix.

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -242,7 +242,7 @@ function run_rust_code(code_block) {
         code: text,
     };
 
-    if(text.includes("#![feature")) {
+    if(text.indexOf("#![feature") !== -1) {
         params.version = "nightly";
     }
 


### PR DESCRIPTION
Yet another fix for missing [String.includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes). Actually, there is a polyfill for it, but since it is just one place - it is easier to use `indexOf` here.

Sorry for two PRs, I didn't expect previous to be merged so fast :)
