### PR TITLE
Fix for playpen buttons missing on mobile safari and chrome IOS

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -408,6 +408,7 @@ table thead td {
 }
 .light pre > .buttons {
   position: absolute;
+  z-index: 100;
   right: 5px;
   top: 5px;
   color: #364149;
@@ -527,6 +528,7 @@ table thead td {
 }
 .coal pre > .buttons {
   position: absolute;
+  z-index: 100;
   right: 5px;
   top: 5px;
   color: #a1adb8;
@@ -646,6 +648,7 @@ table thead td {
 }
 .navy pre > .buttons {
   position: absolute;
+  z-index: 100;
   right: 5px;
   top: 5px;
   color: #c8c9db;
@@ -765,6 +768,7 @@ table thead td {
 }
 .rust pre > .buttons {
   position: absolute;
+  z-index: 100;
   right: 5px;
   top: 5px;
   color: #c8c9db;
@@ -884,6 +888,7 @@ table thead td {
 }
 .ayu pre > .buttons {
   position: absolute;
+  z-index: 100;
   right: 5px;
   top: 5px;
   color: #c8c9db;

--- a/src/theme/stylus/themes/base.styl
+++ b/src/theme/stylus/themes/base.styl
@@ -117,6 +117,7 @@
 
         & > .buttons {
             position: absolute;
+            z-index: 100;
             right: 5px;
             top: 5px;
 


### PR DESCRIPTION
some googling and a hunch later...
it looks like a long standing bug in ios webkit with absolutely possitioned elements without z-index
I've verified it in a coworkers iphone (safari and chrome) and remotely on ios simulator

fixes https://github.com/azerupi/mdBook/issues/325