### PR TITLE
Refactor hbs renderer

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -182,6 +182,16 @@ impl HtmlHandlebars {
         handlebars.register_helper("previous", Box::new(helpers::navigation::previous));
         handlebars.register_helper("next", Box::new(helpers::navigation::next));
     }
+
+    fn copy_additional_css(&self, book: &MDBook) -> Result<(), Box<Error>> {
+        for custom_file in book.get_additional_css()
+                .iter()
+                .chain(book.get_additional_js().iter()) {
+                    self.write_custom_file(custom_file, book)?;
+        }
+
+        Ok(())
+    }
 }
 
 
@@ -198,7 +208,6 @@ impl Renderer for HtmlHandlebars {
         handlebars
             .register_template_string("index", String::from_utf8(theme.index.clone())?)?;
 
-        // Register helpers
         debug!("[*]: Register handlebars helpers");
         self.register_hbs_helpers(&mut handlebars);
 
@@ -236,12 +245,7 @@ impl Renderer for HtmlHandlebars {
         // Copy static files (js, css, images, ...)
         debug!("[*] Copy static files");
         self.copy_static_files(book, &theme)?;
-
-        for custom_file in book.get_additional_css()
-                .iter()
-                .chain(book.get_additional_js().iter()) {
-                    self.write_custom_file(custom_file, book)?;
-        }
+        self.copy_additional_css(book)?;
 
         // Copy all remaining files
         utils::fs::copy_files_except_ext(book.get_source(), &destination, true, &["md"])?;

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -49,7 +49,6 @@ impl HtmlHandlebars {
                         content = helpers::playpen::render_playpen(&content, p);
                     }
 
-                    // Render markdown using the pulldown-cmark crate
                     content = utils::render_markdown(&content);
                     print_content.push_str(&content);
 
@@ -58,6 +57,7 @@ impl HtmlHandlebars {
                         ch.path
                             .to_str()
                             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Could not convert path to str"))?;
+
                     data.insert("path".to_owned(), json!(path));
                     data.insert("content".to_owned(), json!(content));
                     data.insert("chapter_title".to_owned(), json!(ch.name));

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -178,6 +178,8 @@ impl HtmlHandlebars {
         Ok(())
     }
 
+    /// Helper function to write a file to the build directory, normalizing 
+    /// the path to be relative to the book root.
     fn write_custom_file(&self, custom_file: &Path, book: &MDBook) -> Result<(), Box<Error>> {
         let mut data = Vec::new();
         let mut f = File::open(custom_file)?;


### PR DESCRIPTION
In my "plugins" branch I'm wanting to experiment with different ways of doing plugins (for pre-processing, post-processing, different backends, etc) and in the process I needed to refactor the `HTMLHandlebars` renderer a little bit. If you reckon they'll be useful, feel free to merge the changes into master :)

All I did was pull bits and pieces of the `HTMLHandlebars::render()` method out into their own helper functions so it's easier to wrap your head around. 