### PR TITLE
Select right pane content on page load

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -137,6 +137,7 @@ table thead td {
   right: 0;
   left: 0;
   bottom: 0;
+  outline: 0;
   padding-right: 15px;
   overflow-y: auto;
 }

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -52,8 +52,9 @@ $( document ).ready(function() {
 
     // Interesting DOM Elements
     var sidebar = $("#sidebar");
-    var page_wrapper = $("#page-wrapper");
-    var content = $("#content");
+
+    // Help keyboard navigation by always focusing on page content
+    $(".page").focus();
 
     // Toggle sidebar
     $("#sidebar-toggle").click(sidebarToggle);

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -76,7 +76,7 @@
 
         <div id="page-wrapper" class="page-wrapper">
 
-            <div class="page">
+            <div class="page" tabindex="-1">
                 <div id="menu-bar" class="menu-bar">
                     <div class="left-buttons">
                         <i id="sidebar-toggle" class="fa fa-bars"></i>

--- a/src/theme/stylus/page.styl
+++ b/src/theme/stylus/page.styl
@@ -35,6 +35,7 @@
     right: 0
     left: 0
     bottom: 0
+    outline: 0
 
     padding-right: 15px
     overflow-y: auto


### PR DESCRIPTION
fixing problems with keyboard navigation

fixes https://github.com/azerupi/mdBook/issues/235

I also have a variant that selects the right pane whenever sidebar gains focus which is nice as the keyboard navigation always works even if someone misclicks on sidebar not hitting a link. But then keyboard navigation on sidebar itself stops being possible. So I've decided to just post this minimal version as it causes no regressions.