### PR TITLE
Add library path argument for `mdbook test`

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -5,15 +5,18 @@ use get_book_dir;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
-    SubCommand::with_name("test").about("Test that code samples compile")
+    SubCommand::with_name("test")
+        .about("Test that code samples compile")
+        .arg_from_usage("-L, --library-path [DIR]... 'directory to add to crate search path'")
 }
 
 // test command implementation
 pub fn execute(args: &ArgMatches) -> Result<()> {
+    let library_paths: Vec<&str> = args.values_of("library-path").map(|v| v.collect()).unwrap_or_default();
     let book_dir = get_book_dir(args);
     let mut book = MDBook::new(&book_dir).read_config()?;
 
-    book.test()?;
+    book.test(library_paths)?;
 
     Ok(())
 }

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -351,9 +351,13 @@ impl MDBook {
         self
     }
 
-    pub fn test(&mut self) -> Result<()> {
+    pub fn test(&mut self, library_paths: Vec<&str>) -> Result<()> {
         // read in the chapters
         self.parse_summary().chain_err(|| "Couldn't parse summary")?;
+        let library_args: Vec<&str> = (0..library_paths.len()).map(|_| "-L")
+                                                              .zip(library_paths.into_iter())
+                                                              .flat_map(|x| vec![x.0, x.1])
+                                                              .collect();
         for item in self.iter() {
 
             if let BookItem::Chapter(_, ref ch) = *item {
@@ -363,7 +367,7 @@ impl MDBook {
 
                     println!("[*]: Testing file: {:?}", path);
 
-                    let output = Command::new("rustdoc").arg(&path).arg("--test").output()?;
+                    let output = Command::new("rustdoc").arg(&path).arg("--test").args(&library_args).output()?;
 
                     if !output.status.success() {
                         bail!(ErrorKind::Subprocess("Rustdoc returned an error".to_string(), output));


### PR DESCRIPTION
Add `-L`/`--library-path` argument and pass it into `rustdoc` should be sufficient.

Closes #339 