### PR TITLE
Creating markdown code from playpen files instead of HTML #345

### DIFF
--- a/src/renderer/html_handlebars/helpers/playpen.rs
+++ b/src/renderer/html_handlebars/helpers/playpen.rs
@@ -36,7 +36,12 @@ pub fn render_playpen(s: &str, path: &Path) -> String {
             continue;
         };
 
-        let replacement = String::new() + "<pre><code class=\"language-rust\">" + &file_content + "</code></pre>";
+        let mut editable = "";
+        if playpen.editable {
+            editable = ",editable";
+        }
+
+        let replacement = String::new() + "``` rust" + editable + "\n" + &file_content + "\n```\n";
 
         replaced.push_str(&s[previous_end_index..playpen.start_index]);
         replaced.push_str(&replacement);


### PR DESCRIPTION
Potential code for #345 for reference. Adding `editable` passthrough while we're at it.

Doing something like may have unintended consequences, of course.