### PR TITLE
Initial `Book` loader and summary parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ ws = { version = "0.7", optional = true}
 # Tests
 [dev-dependencies]
 tempdir = "0.3.4"
+pretty_assertions = "0.2.1"
 
 [build-dependencies]
 error-chain = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,13 +76,17 @@ extern crate serde_derive;
 extern crate serde;
 #[macro_use] 
 extern crate serde_json;
+#[macro_use]
+extern crate log;
 
 extern crate handlebars;
 extern crate pulldown_cmark;
 extern crate regex;
 
+#[cfg(test)]
 #[macro_use]
-extern crate log;
+extern crate pretty_assertions;
+
 pub mod book;
 pub mod config;
 mod parse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ mod parse;
 pub mod renderer;
 pub mod theme;
 pub mod utils;
+pub mod loader;
 
 pub use book::MDBook;
 pub use book::BookItem;

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -27,14 +27,15 @@ impl Loader {
 
     /// Parse the summary file and use it to load a book from disk.
     pub fn load(&self) -> Result<()> {
-        let summary = self.parse_summary()
-            .chain_err(|| "Couldn't parse `SUMMARY.md`")?;
+        let summary = self.parse_summary().chain_err(
+            || "Couldn't parse `SUMMARY.md`",
+        )?;
 
         unimplemented!()
     }
 
     /// Parse the `SUMMARY.md` file.
-    fn parse_summary(&self) -> Result<Summary> {
+    pub fn parse_summary(&self) -> Result<Summary> {
         let path = self.source_directory.join("SUMMARY.md");
 
         let mut summary_content = String::new();
@@ -42,5 +43,4 @@ impl Loader {
 
         summary::parse_summary(&summary_content)
     }
-
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -3,9 +3,9 @@
 #![deny(missing_docs)]
 
 use std::path::{Path, PathBuf};
-use std::error::Error;
 use std::fs::File;
 use std::io::Read;
+use errors::*;
 
 mod summary;
 
@@ -26,7 +26,7 @@ impl Loader {
     }
 
     /// Parse the `SUMMARY.md` file.
-    pub fn parse_summary(&self) -> Result<Summary, Box<Error>> {
+    pub fn parse_summary(&self) -> Result<Summary> {
         let path = self.source_directory.join("SUMMARY.md");
 
         let mut summary_content = String::new();

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -25,8 +25,16 @@ impl Loader {
         Loader { source_directory: source_directory.as_ref().to_path_buf() }
     }
 
+    /// Parse the summary file and use it to load a book from disk.
+    pub fn load(&self) -> Result<()> {
+        let summary = self.parse_summary()
+            .chain_err(|| "Couldn't parse `SUMMARY.md`")?;
+
+        unimplemented!()
+    }
+
     /// Parse the `SUMMARY.md` file.
-    pub fn parse_summary(&self) -> Result<Summary> {
+    fn parse_summary(&self) -> Result<Summary> {
         let path = self.source_directory.join("SUMMARY.md");
 
         let mut summary_content = String::new();
@@ -34,4 +42,5 @@ impl Loader {
 
         summary::parse_summary(&summary_content)
     }
+
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -4,6 +4,12 @@
 
 use std::path::{Path, PathBuf};
 use std::error::Error;
+use std::fs::File;
+use std::io::Read;
+
+mod summary;
+
+pub use self::summary::Summary;
 
 
 /// The object in charge of parsing the source directory into a usable
@@ -21,9 +27,11 @@ impl Loader {
 
     /// Parse the `SUMMARY.md` file.
     pub fn parse_summary(&self) -> Result<Summary, Box<Error>> {
-        unimplemented!()
+        let path = self.source_directory.join("SUMMARY.md");
+
+        let mut summary_content = String::new();
+        File::open(&path)?.read_to_string(&mut summary_content)?;
+
+        summary::parse_summary(&summary_content)
     }
 }
-
-/// The parsed `SUMMARY.md`, specifying how the book should be laid out.
-pub struct Summary;

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -1,4 +1,42 @@
 //! Functionality for loading the internal book representation from disk.
+//!
+//! The typical use case is to create a `Loader` pointing at the correct
+//! source directory then call the `load()` method. Internally this will
+//! search for the `SUMMARY.md` file, parse it, then use the parsed
+//! `Summary` to construct an in-memory representation of the entire book.
+//!
+//! # Examples
+//!
+//! ```rust,no_run
+//! # fn run() -> mdbook::errors::Result<()> {
+//! use mdbook::loader::Loader;
+//! let loader = Loader::new("./src/");
+//! let book = loader.load()?;
+//! # Ok(())
+//! # }
+//! # fn main() { run().unwrap() }
+//! ```
+//!
+//! Alternatively, if you are using the `mdbook` crate as a library and
+//! only want to read the `SUMMARY.md` file without having to load the
+//! entire book from disk, you can use the `parse_summary()` function.
+//!
+//! ```rust
+//! # fn run() -> mdbook::errors::Result<()> {
+//! use mdbook::loader::parse_summary;
+//! let src = "# Book Summary
+//!
+//! [Introduction](./index.md)
+//! - [First Chapter](./first/index.md)
+//!   - [Sub-Section](./first/subsection.md)
+//! - [Second Chapter](./second/index.md)
+//! ";
+//! let summary = parse_summary(src)?;
+//! println!("{:#?}", summary);
+//! # Ok(())
+//! # }
+//! # fn main() { run().unwrap() }
+//! ```
 
 #![deny(missing_docs)]
 

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -9,7 +9,7 @@ use std::io::Read;
 
 mod summary;
 
-pub use self::summary::Summary;
+pub use self::summary::{Summary, parse_summary};
 
 
 /// The object in charge of parsing the source directory into a usable

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -1,0 +1,29 @@
+//! Functionality for loading the internal book representation from disk.
+
+#![deny(missing_docs)]
+
+use std::path::{Path, PathBuf};
+use std::error::Error;
+
+
+/// The object in charge of parsing the source directory into a usable
+/// `Book` struct.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Loader {
+    source_directory: PathBuf,
+}
+
+impl Loader {
+    /// Create a new loader which uses the provided source directory.
+    pub fn new<P: AsRef<Path>>(source_directory: P) -> Loader {
+        Loader { source_directory: source_directory.as_ref().to_path_buf() }
+    }
+
+    /// Parse the `SUMMARY.md` file.
+    pub fn parse_summary(&self) -> Result<Summary, Box<Error>> {
+        unimplemented!()
+    }
+}
+
+/// The parsed `SUMMARY.md`, specifying how the book should be laid out.
+pub struct Summary;

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -9,7 +9,7 @@ use errors::*;
 
 mod summary;
 
-pub use self::summary::{Summary, parse_summary};
+pub use self::summary::{Summary, Link, SummaryItem, parse_summary, SectionNumber};
 
 
 /// The object in charge of parsing the source directory into a usable

--- a/src/loader/summary.rs
+++ b/src/loader/summary.rs
@@ -1,18 +1,141 @@
 use std::error::Error;
 use std::fmt::{self, Formatter, Display};
 use std::ops::{Deref, DerefMut};
-use pulldown_cmark;
+use pulldown_cmark::{self, Event, Tag};
 
+
+/// Parse the text from a `SUMMARY.md` file into a sort of "recipe" to be
+/// used when loading a book from disk.
+///
+/// # Summary Format
+///
+/// **Title:** It's common practice to begin with a title, generally 
+/// "# Summary". But it is not mandatory, the parser just ignores it. So you 
+/// can too if you feel like it.
+/// 
+/// **Prefix Chapter:** Before the main numbered chapters you can add a couple 
+/// of elements that will not be numbered. This is useful for forewords,
+/// introductions, etc. There are however some constraints. You can not nest
+/// prefix chapters, they should all be on the root level. And you can not add
+/// prefix chapters once you have added numbered chapters.
+/// 
+/// ```markdown
+/// [Title of prefix element](relative/path/to/markdown.md)
+/// ```
+/// 
+/// **Numbered Chapter:** Numbered chapters are the main content of the book, they
+/// will be numbered and can be nested, resulting in a nice hierarchy (chapters,
+/// sub-chapters, etc.)
+/// 
+/// ```markdown
+/// - [Title of the Chapter](relative/path/to/markdown.md)
+/// ```
+/// 
+/// You can either use - or * to indicate a numbered chapter.
+/// 
+/// **Suffix Chapter:** After the numbered chapters you can add a couple of
+/// non-numbered chapters. They are the same as prefix chapters but come after
+/// the numbered chapters instead of before.
+/// 
+/// All other elements are unsupported and will be ignored at best or result in
+/// an error.
+pub fn parse_summary(summary: &str) -> Result<Summary, Box<Error>> {
+    let parser = SummaryParser::new(summary);
+    parser.parse()    
+}
 
 /// The parsed `SUMMARY.md`, specifying how the book should be laid out.
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Summary {
     title: Option<String>,
 }
 
-/// Parse the text from a `SUMMARY.md` file into a sort of "recipe" to be
-/// used when loading a book from disk.
-pub fn parse_summary(summary: &str) -> Result<Summary, Box<Error>> {
-    unimplemented!()
+/// A stateful parser for parsing a `SUMMARY.md` file.
+///
+/// # Grammar
+/// 
+/// The `SUMMARY.md` file has a grammar which looks something like this:
+///
+/// ```text
+/// summary           ::= title prefix_chapters numbered_chapters suffix_chapters
+/// title             ::= "# " TEXT
+///                     | EPSILON
+/// prefix_chapters   ::= item*
+/// suffix_chapters   ::= item*
+/// numbered_chapters ::= dotted_item+
+/// dotted_item       ::= INDENT* DOT_POINT item
+/// item              ::= link 
+///                     | separator
+/// separator         ::= "---"
+/// link              ::= "[" TEXT "]" "(" TEXT ")"
+/// DOT_POINT         ::= "-"
+///                     | "*"
+/// ```
+/// 
+/// > **Note:** the `TEXT` terminal is "normal" text, and should (roughly) 
+/// > match the following regex: "[^<>\n[]]+".
+struct SummaryParser<'a> {
+    stream: pulldown_cmark::Parser<'a>,
+    summary: Summary,
+}
+
+impl<'a> SummaryParser<'a> 
+{
+    fn new(text: &str) -> SummaryParser {
+        let pulldown_parser = pulldown_cmark::Parser::new(text);
+        let intermediate_summary = Summary::default();
+
+        SummaryParser {
+            stream: pulldown_parser,
+            summary: intermediate_summary,
+        }
+    }
+
+    fn parse(mut self) -> Result<Summary, Box<Error>> {
+        self.summary.title = self.parse_title();
+
+        Ok(self.summary)        
+    }
+
+    fn parse_title(&mut self) -> Option<String> {
+        if let Some(Event::Start(Tag::Header(1))) = self.stream.next() {
+            debug!("[*] Found a h1 in the SUMMARY");
+            
+            let mut tags = Vec::new();
+
+            loop {
+                let next_event = self.stream.next();
+                match next_event {
+                    Some(Event::End(Tag::Header(1))) => break,
+                    Some(other) => tags.push(other),
+                    None => {
+                        // If we ever get here then changes are pulldown_cmark 
+                        // is seriously broken. It means there's an opening 
+                        // <h1> tag but not a closing one. It also means 
+                        // we've consumed the entire stream of events, so
+                        // chances are any parsing after this will just hit
+                        // EOF and end early :(
+                        warn!("[*] No closing <h1> tag in the SUMMARY.md file");
+                        break;
+                    }
+                }
+            }
+
+            // TODO: How do we deal with headings like "# My **awesome** summary"?
+            // for now, I'm just going to scan through and concatenate the 
+            // Event::Text tags, skipping any styling.
+            let title: String = tags.into_iter()
+                .filter_map(|t| match t {
+                    Event::Text(text) => Some(text),
+                    _ => None,
+                })
+                .collect();
+
+            Some(title)
+        } else {
+            None
+        }
+    }
 }
 
 /// A section number like "1.2.3", basically just a newtype'd `Vec<u32>`.
@@ -60,5 +183,27 @@ mod tests {
 
             assert_eq!(string_repr, should_be);
         }
+    }
+
+    #[test]
+    fn parse_initial_title() {
+        let src = "# Summary";
+        let should_be = String::from("Summary");
+
+        let mut parser = SummaryParser::new(src);
+        let got = parser.parse_title().unwrap();
+
+        assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn parse_title_with_styling() {
+        let src = "# My **Awesome** Summary";
+        let should_be = String::from("My Awesome Summary");
+
+        let mut parser = SummaryParser::new(src);
+        let got = parser.parse_title().unwrap();
+
+        assert_eq!(got, should_be);
     }
 }

--- a/src/loader/summary.rs
+++ b/src/loader/summary.rs
@@ -11,39 +11,40 @@ use pulldown_cmark::{self, Event, Tag};
 ///
 /// # Summary Format
 ///
-/// **Title:** It's common practice to begin with a title, generally 
-/// "# Summary". But it is not mandatory, the parser just ignores it. So you 
+/// **Title:** It's common practice to begin with a title, generally
+/// "# Summary". But it is not mandatory, the parser just ignores it. So you
 /// can too if you feel like it.
-/// 
-/// **Prefix Chapter:** Before the main numbered chapters you can add a couple 
+///
+/// **Prefix Chapter:** Before the main numbered chapters you can add a couple
 /// of elements that will not be numbered. This is useful for forewords,
 /// introductions, etc. There are however some constraints. You can not nest
 /// prefix chapters, they should all be on the root level. And you can not add
 /// prefix chapters once you have added numbered chapters.
-/// 
+///
 /// ```markdown
 /// [Title of prefix element](relative/path/to/markdown.md)
 /// ```
-/// 
-/// **Numbered Chapter:** Numbered chapters are the main content of the book, they
+///
+/// **Numbered Chapter:** Numbered chapters are the main content of the book,
+/// they
 /// will be numbered and can be nested, resulting in a nice hierarchy (chapters,
 /// sub-chapters, etc.)
-/// 
+///
 /// ```markdown
 /// - [Title of the Chapter](relative/path/to/markdown.md)
 /// ```
-/// 
+///
 /// You can either use - or * to indicate a numbered chapter.
-/// 
+///
 /// **Suffix Chapter:** After the numbered chapters you can add a couple of
 /// non-numbered chapters. They are the same as prefix chapters but come after
 /// the numbered chapters instead of before.
-/// 
+///
 /// All other elements are unsupported and will be ignored at best or result in
 /// an error.
 pub fn parse_summary(summary: &str) -> Result<Summary, Box<Error>> {
     let parser = SummaryParser::new(summary);
-    parser.parse()    
+    parser.parse()
 }
 
 /// The parsed `SUMMARY.md`, specifying how the book should be laid out.
@@ -52,7 +53,7 @@ pub struct Summary {
     title: Option<String>,
 }
 
-/// A struct representing an entry in the `SUMMARY.md`, possibly with nested 
+/// A struct representing an entry in the `SUMMARY.md`, possibly with nested
 /// entries.
 ///
 /// This is roughly the equivalent of `[Some section](./path/to/file.md)`.
@@ -69,41 +70,53 @@ enum SummaryItem {
     Separator,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+enum State {
+    Begin,
+    PrefixChapters,
+    /// Numbered chapters, including the nesting level.
+    NumberedChapters(u32),
+    SuffixChapters,
+    End,
+}
+
 /// A stateful parser for parsing a `SUMMARY.md` file.
 ///
 /// # Grammar
-/// 
+///
 /// The `SUMMARY.md` file has a grammar which looks something like this:
 ///
 /// ```text
-/// summary           ::= title prefix_chapters numbered_chapters suffix_chapters
+/// summary           ::= title prefix_chapters numbered_chapters
+/// suffix_chapters
 /// title             ::= "# " TEXT
 ///                     | EPSILON
 /// prefix_chapters   ::= item*
 /// suffix_chapters   ::= item*
 /// numbered_chapters ::= dotted_item+
 /// dotted_item       ::= INDENT* DOT_POINT item
-/// item              ::= link 
+/// item              ::= link
 ///                     | separator
 /// separator         ::= "---"
 /// link              ::= "[" TEXT "]" "(" TEXT ")"
 /// DOT_POINT         ::= "-"
 ///                     | "*"
 /// ```
-/// 
-/// > **Note:** the `TEXT` terminal is "normal" text, and should (roughly) 
+///
+/// > **Note:** the `TEXT` terminal is "normal" text, and should (roughly)
 /// > match the following regex: "[^<>\n[]]+".
 struct SummaryParser<'a> {
     stream: pulldown_cmark::Parser<'a>,
     summary: Summary,
+    state: State,
 }
 
 /// Reads `Events` from the provided stream until the corresponding
 /// `Event::End` is encountered which matches the `$delimiter` pattern.
 ///
-/// This is the equivalent of doing 
-/// `$stream.take_while(|e| e != $delimeter).collect()` but it allows you to 
-/// use pattern matching and you won't get errors because `take_while()` 
+/// This is the equivalent of doing
+/// `$stream.take_while(|e| e != $delimeter).collect()` but it allows you to
+/// use pattern matching and you won't get errors because `take_while()`
 /// moves `$stream` out of self.
 macro_rules! collect_events {
     ($stream:expr, $delimiter:pat) => {
@@ -127,8 +140,7 @@ macro_rules! collect_events {
     }
 }
 
-impl<'a> SummaryParser<'a> 
-{
+impl<'a> SummaryParser<'a> {
     fn new(text: &str) -> SummaryParser {
         let pulldown_parser = pulldown_cmark::Parser::new(text);
         let intermediate_summary = Summary::default();
@@ -136,6 +148,7 @@ impl<'a> SummaryParser<'a>
         SummaryParser {
             stream: pulldown_parser,
             summary: intermediate_summary,
+            state: State::Begin,
         }
     }
 
@@ -143,17 +156,38 @@ impl<'a> SummaryParser<'a>
     fn parse(mut self) -> Result<Summary, Box<Error>> {
         self.summary.title = self.parse_title();
 
-        Ok(self.summary)        
+        Ok(self.summary)
+    }
+
+    fn step(&mut self) -> Result<(), Box<Error>> {
+        let next_event = self.stream.next().expect("TODO: error-chain");
+        trace!("[*] Current state = {:?}, Next Event = {:?}", self.state, next_event);
+    
+        match self.state {
+            State::Begin => self.step_start(next_event),
+            other => unimplemented!()
+        }
+    }
+
+    /// The very first state, we should see a `BeginParagraph` token or
+    /// it's an error...
+    fn step_start(&mut self, event: Event<'a>) -> Result<(), Box<Error>> {
+        match event {
+            Event::Start(Tag::Paragraph) => self.state = State::PrefixChapters,
+            other => panic!("Unexpected tag! {:?}", other),
+        }
+
+        Ok(())
     }
 
     fn parse_title(&mut self) -> Option<String> {
         if let Some(Event::Start(Tag::Header(1))) = self.stream.next() {
             debug!("[*] Found a h1 in the SUMMARY");
-            
+
             let tags = collect_events!(self.stream, Tag::Header(1));
 
             // TODO: How do we deal with headings like "# My **awesome** summary"?
-            // for now, I'm just going to scan through and concatenate the 
+            // for now, I'm just going to scan through and concatenate the
             // Event::Text tags, skipping any styling.
             Some(stringify_events(tags))
         } else {
@@ -179,15 +213,15 @@ impl<'a> SummaryParser<'a>
     }
 }
 
-/// Extract just the text from a bunch of events and concatenate it into a
-/// single string.
+/// Extracts the text from formatted markdown.
 fn stringify_events<'a>(events: Vec<Event<'a>>) -> String {
-    events.into_iter()
-                .filter_map(|t| match t {
-                    Event::Text(text) => Some(text),
-                    _ => None,
-                })
-                .collect()
+    events
+        .into_iter()
+        .filter_map(|t| match t {
+            Event::Text(text) => Some(text.into_owned()),
+            _ => None,
+        })
+        .collect()
 }
 
 /// A section number like "1.2.3", basically just a newtype'd `Vec<u32>`.
@@ -196,9 +230,11 @@ struct SectionNumber(Vec<u32>);
 
 impl Display for SectionNumber {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let dotted_number: String = self.0.iter().map(|i| format!("{}", i))
-        .collect::<Vec<String>>()
-        .join(".");
+        let dotted_number: String = self.0
+            .iter()
+            .map(|i| format!("{}", i))
+            .collect::<Vec<String>>()
+            .join(".");
 
         write!(f, "{}", dotted_number)
     }
@@ -273,5 +309,28 @@ mod tests {
         let got = parser.parse_item().unwrap();
 
         assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn convert_markdown_events_to_a_string() {
+        let src = "Hello *World*, `this` is some text [and a link](./path/to/link)";
+        let should_be = "Hello World, this is some text and a link";
+
+        let events = pulldown_cmark::Parser::new(src).collect();
+        let got = stringify_events(events);
+
+        assert_eq!(got, should_be);
+
+    }
+
+    #[test]
+    fn can_step_past_first_token() {
+        let src = "hello world";
+        let should_be = State::PrefixChapters;
+
+        let mut parser = SummaryParser::new(src);
+        assert_eq!(parser.state, State::Begin);
+        parser.step().unwrap();
+        assert_eq!(parser.state, should_be);
     }
 }

--- a/src/loader/summary.rs
+++ b/src/loader/summary.rs
@@ -1,9 +1,64 @@
 use std::error::Error;
+use std::fmt::{self, Formatter, Display};
+use std::ops::{Deref, DerefMut};
 use pulldown_cmark;
 
-/// The parsed `SUMMARY.md`, specifying how the book should be laid out.
-pub struct Summary;
 
+/// The parsed `SUMMARY.md`, specifying how the book should be laid out.
+pub struct Summary {
+    title: Option<String>,
+}
+
+/// Parse the text from a `SUMMARY.md` file into a sort of "recipe" to be
+/// used when loading a book from disk.
 pub fn parse_summary(summary: &str) -> Result<Summary, Box<Error>> {
     unimplemented!()
+}
+
+/// A section number like "1.2.3", basically just a newtype'd `Vec<u32>`.
+#[derive(Debug, PartialEq, Clone, Default)]
+struct SectionNumber(Vec<u32>);
+
+impl Display for SectionNumber {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let dotted_number: String = self.0.iter().map(|i| format!("{}", i))
+        .collect::<Vec<String>>()
+        .join(".");
+
+        write!(f, "{}", dotted_number)
+    }
+}
+
+impl Deref for SectionNumber {
+    type Target = Vec<u32>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for SectionNumber {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn section_number_has_correct_dotted_representation() {
+        let inputs = vec![
+            (vec![0], "0"),
+            (vec![1, 3], "1.3"),
+            (vec![1, 2, 3], "1.2.3"),
+        ];
+
+        for (input, should_be) in inputs {
+            let section_number = SectionNumber(input);
+            let string_repr = format!("{}", section_number);
+
+            assert_eq!(string_repr, should_be);
+        }
+    }
 }

--- a/src/loader/summary.rs
+++ b/src/loader/summary.rs
@@ -62,7 +62,7 @@ pub struct Summary {
 /// entries.
 ///
 /// This is roughly the equivalent of `[Some section](./path/to/file.md)`.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 struct Link {
     name: String,
     location: PathBuf,
@@ -75,6 +75,17 @@ impl Link {
         Link {
             name: name.into(),
             location: location.as_ref().to_path_buf(),
+            number: None,
+            nested_items: Vec::new(),
+        }
+    }
+}
+
+impl Default for Link {
+    fn default() -> Self {
+        Link {
+            name: String::new(),
+            location: PathBuf::new(),
             number: None,
             nested_items: Vec::new(),
         }

--- a/src/loader/summary.rs
+++ b/src/loader/summary.rs
@@ -1,0 +1,9 @@
+use std::error::Error;
+use pulldown_cmark;
+
+/// The parsed `SUMMARY.md`, specifying how the book should be laid out.
+pub struct Summary;
+
+pub fn parse_summary(summary: &str) -> Result<Summary, Box<Error>> {
+    unimplemented!()
+}

--- a/tests/loading.rs
+++ b/tests/loading.rs
@@ -30,6 +30,7 @@ const SUMMARY: &'static str = "
 fn parse_summary_md() {
     env_logger::init().unwrap();
 
+    // Hard-code the structure `SUMMARY` *should* be parsed into.
     let should_be = Summary {
         title: Some(String::from("Summary")),
 

--- a/tests/loading.rs
+++ b/tests/loading.rs
@@ -25,8 +25,7 @@ const SUMMARY: &str = "
 ";
 
 #[test]
-#[ignore]
-fn load_summary_md() {
+fn parse_summary_md() {
     env_logger::init().unwrap();
 
     let should_be = Summary {

--- a/tests/loading.rs
+++ b/tests/loading.rs
@@ -1,5 +1,7 @@
 //! Integration tests for loading a book into memory
 
+#[macro_use]
+extern crate pretty_assertions;
 extern crate mdbook;
 extern crate env_logger;
 
@@ -7,7 +9,7 @@ use std::path::PathBuf;
 use mdbook::loader::{parse_summary, Link, SummaryItem, SectionNumber, Summary};
 
 
-const SUMMARY: &str = "
+const SUMMARY: &'static str = "
 # Summary
 
 [Introduction](/intro.md)
@@ -16,7 +18,7 @@ const SUMMARY: &str = "
 
 [A Prefix Chapter](/some_prefix.md)
 
-- [First chapter](/chapter_1/index.md)
+- [First Chapter](/chapter_1/index.md)
   - [Some Subsection](/chapter_1/subsection.md)
 
 ---

--- a/tests/loading.rs
+++ b/tests/loading.rs
@@ -1,0 +1,82 @@
+//! Integration tests for loading a book into memory
+
+extern crate mdbook;
+extern crate env_logger;
+
+use std::path::PathBuf;
+use mdbook::loader::{parse_summary, Link, SummaryItem, SectionNumber, Summary};
+
+
+const SUMMARY: &str = "
+# Summary
+
+[Introduction](/intro.md)
+
+---
+
+[A Prefix Chapter](/some_prefix.md)
+
+- [First chapter](/chapter_1/index.md)
+  - [Some Subsection](/chapter_1/subsection.md)
+
+---
+
+[Conclusion](/conclusion.md)
+";
+
+#[test]
+#[ignore]
+fn load_summary_md() {
+    env_logger::init().unwrap();
+
+    let should_be = Summary {
+        title: Some(String::from("Summary")),
+
+        prefix_chapters: vec![
+            SummaryItem::Link(Link {
+                name: String::from("Introduction"),
+                location: PathBuf::from("/intro.md"),
+                number: None,
+                nested_items: vec![],
+            }),
+            SummaryItem::Separator,
+            SummaryItem::Link(Link {
+                name: String::from("A Prefix Chapter"),
+                location: PathBuf::from("/some_prefix.md"),
+                number: None,
+                nested_items: vec![],
+            }),
+        ],
+
+        numbered_chapters: vec![
+            SummaryItem::Link(Link {
+                name: String::from("First Chapter"),
+                location: PathBuf::from("/chapter_1/index.md"),
+                number: Some(SectionNumber(vec![1])),
+                nested_items: vec![
+                    SummaryItem::Link(Link {
+                        name: String::from("Some Subsection"),
+                        location: PathBuf::from("/chapter_1/subsection.md"),
+                        number: Some(SectionNumber(vec![1, 1])),
+                        nested_items: vec![],
+                    }),
+                ],
+            }),
+        ],
+
+        suffix_chapters: vec![
+            SummaryItem::Separator,
+            SummaryItem::Link( Link {
+                name: String::from("Conclusion"),
+                location: PathBuf::from("/conclusion.md"),
+                number: None,
+                nested_items: vec![],
+            })
+        ],
+    };
+
+    let got = parse_summary(SUMMARY).unwrap();
+    println!("{:#?}", got);
+
+    assert_eq!(got, should_be);
+}


### PR DESCRIPTION
This is the first step towards #359, creating a `Loader` type which is in charge of reading the source directory, parsing the `SUMMARY.md`, and then constructing an internal representation of the book.

This PR will refactor the existing summary parsing to return some `Summary` struct which indicates how the book is structured so that later steps can locate files and populate the book from disk.