### PR TITLE
Make HtmlConfig is no longer optional

### DIFF
--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -34,10 +34,8 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     book.build()?;
 
-    if let Some(d) = book.get_destination() {
-        if args.is_present("open") {
-            open(d.join("index.html"));
-        }
+    if args.is_present("open") {
+        open(book.get_destination().join("index.html"));
     }
 
     Ok(())

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -49,9 +49,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     }
 
     // Because of `src/book/mdbook.rs#L37-L39`, `dest` will always start with `root`
-    let is_dest_inside_root = book.get_destination()
-        .map(|p| p.starts_with(book.get_root()))
-        .unwrap_or(false);
+    let is_dest_inside_root = book.get_destination().starts_with(book.get_root());
 
     if !args.is_present("force") && is_dest_inside_root {
         println!("\nDo you want a .gitignore to be created? (y/n)");

--- a/src/bin/serve.rs
+++ b/src/bin/serve.rs
@@ -40,11 +40,6 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
         None => book,
     };
 
-    if let None = book.get_destination() {
-        println!("The HTML renderer is not set up, impossible to serve the files.");
-        std::process::exit(2);
-    }
-
     if args.is_present("curly-quotes") {
         book = book.with_curly_quotes(true);
     }
@@ -79,8 +74,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     book.build()?;
 
-    let mut chain = Chain::new(staticfile::Static::new(book.get_destination()
-                                                           .expect("destination is present, checked before")));
+    let mut chain = Chain::new(staticfile::Static::new(book.get_destination()));
     chain.link_after(ErrorRecover);
     let _iron = Iron::new(chain).http(&*address).unwrap();
 

--- a/src/bin/watch.rs
+++ b/src/bin/watch.rs
@@ -37,9 +37,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 
     if args.is_present("open") {
         book.build()?;
-        if let Some(d) = book.get_destination() {
-            open(d.join("index.html"));
-        }
+        open(book.get_destination().join("index.html"));
     }
 
     trigger_on_change(&mut book, |path, book| {
@@ -78,9 +76,7 @@ pub fn trigger_on_change<F>(book: &mut MDBook, closure: F) -> ()
     };
 
     // Add the theme directory to the watcher
-    if let Some(t) = book.get_theme_path() {
-        watcher.watch(t, Recursive).unwrap_or_default();
-    }
+    watcher.watch(book.get_theme_path(), Recursive).unwrap_or_default();
 
 
     // Add the book.{json,toml} file to the watcher if it exists, because it's not

--- a/src/config/bookconfig.rs
+++ b/src/config/bookconfig.rs
@@ -5,7 +5,7 @@ use super::tomlconfig::TomlConfig;
 use super::jsonconfig::JsonConfig;
 
 /// Configuration struct containing all the configuration options available in mdBook.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BookConfig {
     root: PathBuf,
     source: PathBuf,
@@ -17,7 +17,7 @@ pub struct BookConfig {
     multilingual: bool,
     indent_spaces: i32,
 
-    html_config: Option<HtmlConfig>,
+    html_config: HtmlConfig,
 }
 
 impl BookConfig {
@@ -33,7 +33,7 @@ impl BookConfig {
     ///
     /// assert_eq!(config.get_root(), &root);
     /// assert_eq!(config.get_source(), PathBuf::from("directory/to/my/book/src"));
-    /// assert_eq!(config.get_html_config(), Some(&HtmlConfig::new(PathBuf::from("directory/to/my/book"))));
+    /// assert_eq!(config.get_html_config(), &HtmlConfig::new(PathBuf::from("directory/to/my/book")));
     /// ```
     pub fn new<T: Into<PathBuf>>(root: T) -> Self {
         let root: PathBuf = root.into();
@@ -50,7 +50,7 @@ impl BookConfig {
             multilingual: false,
             indent_spaces: 4,
 
-            html_config: Some(htmlconfig),
+            html_config: htmlconfig,
         }
     }
 
@@ -109,9 +109,8 @@ impl BookConfig {
 
         if let Some(tomlhtmlconfig) = tomlconfig.output.and_then(|o| o.html) {
             let root = self.root.clone();
-            if let Some(htmlconfig) = self.get_mut_html_config() {
-                htmlconfig.fill_from_tomlconfig(root, tomlhtmlconfig);
-            }
+            self.get_mut_html_config()
+                .fill_from_tomlconfig(root, tomlhtmlconfig);
         }
 
         self
@@ -148,16 +147,14 @@ impl BookConfig {
 
         if let Some(d) = jsonconfig.dest {
             let root = self.get_root().to_owned();
-            if let Some(htmlconfig) = self.get_mut_html_config() {
-                htmlconfig.set_destination(&root, &d);
-            }
+            self.get_mut_html_config()
+                .set_destination(&root, &d);
         }
 
         if let Some(d) = jsonconfig.theme_path {
             let root = self.get_root().to_owned();
-            if let Some(htmlconfig) = self.get_mut_html_config() {
-                htmlconfig.set_theme(&root, &d);
-            }
+            self.get_mut_html_config()
+                .set_theme(&root, &d);
         }
 
         self
@@ -217,16 +214,16 @@ impl BookConfig {
     }
 
     pub fn  set_html_config(&mut self, htmlconfig: HtmlConfig) -> &mut Self {
-        self.html_config = Some(htmlconfig);
+        self.html_config = htmlconfig;
         self
     }
 
     /// Returns the configuration for the HTML renderer or None of there isn't any
-    pub fn get_html_config(&self) -> Option<&HtmlConfig> {
-        self.html_config.as_ref()
+    pub fn get_html_config(&self) -> &HtmlConfig {
+        &self.html_config
     }
 
-    pub fn get_mut_html_config(&mut self) -> Option<&mut HtmlConfig> {
-        self.html_config.as_mut()
+    pub fn get_mut_html_config(&mut self) -> &mut HtmlConfig {
+        &mut self.html_config
     }
 }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -110,10 +110,6 @@ impl HtmlHandlebars {
         info!(
             "[*] Creating index.html from {:?} ✓",
             book.get_destination()
-                .expect(
-                    "If the HTML renderer is called, one would assume the HtmlConfig is \
-                                            set... (4)",
-                )
                 .join(&ch.path.with_extension("html"))
         );
 
@@ -252,9 +248,7 @@ impl Renderer for HtmlHandlebars {
         // Print version
         let mut print_content = String::new();
 
-        let destination = book.get_destination().expect(
-            "If the HTML renderer is called, one would assume the HtmlConfig is set... (2)",
-        );
+        let destination = book.get_destination();
 
         debug!("[*]: Check if destination directory exists");
         if fs::create_dir_all(&destination).is_err() {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -46,7 +46,7 @@ pub struct Theme {
 }
 
 impl Theme {
-    pub fn new(src: Option<&Path>) -> Self {
+    pub fn new(src: &Path) -> Self {
 
         // Default theme
         let mut theme = Theme {
@@ -64,11 +64,9 @@ impl Theme {
         };
 
         // Check if the given path exists
-        if src.is_none() || !src.unwrap().exists() || !src.unwrap().is_dir() {
+        if !src.exists() || !src.is_dir() {
             return theme;
         }
-
-        let src = src.unwrap();
 
         // Check for individual files if they exist
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -20,14 +20,14 @@ fn do_not_overwrite_unspecified_config_values() {
 
     assert_eq!(book.get_root(), dir.path());
     assert_eq!(book.get_source(), dir.path().join("bar"));
-    assert_eq!(book.get_destination().unwrap(), dir.path().join("baz"));
+    assert_eq!(book.get_destination(), dir.path().join("baz"));
 
     // Test when trying to read a config file that does not exist
     let book = book.read_config().expect("Error reading the config file");
 
     assert_eq!(book.get_root(), dir.path());
     assert_eq!(book.get_source(), dir.path().join("bar"));
-    assert_eq!(book.get_destination().unwrap(), dir.path().join("baz"));
+    assert_eq!(book.get_destination(), dir.path().join("baz"));
     assert_eq!(book.get_mathjax_support(), true);
 
     // Try with a partial config file
@@ -40,7 +40,7 @@ fn do_not_overwrite_unspecified_config_values() {
 
     assert_eq!(book.get_root(), dir.path());
     assert_eq!(book.get_source(), dir.path().join("barbaz"));
-    assert_eq!(book.get_destination().unwrap(), dir.path().join("baz"));
+    assert_eq!(book.get_destination(), dir.path().join("baz"));
     assert_eq!(book.get_mathjax_support(), true);
 }
 

--- a/tests/jsonconfig.rs
+++ b/tests/jsonconfig.rs
@@ -66,7 +66,7 @@ fn from_json_destination() {
     let parsed = JsonConfig::from_json(json).expect("This should parse");
     let config = BookConfig::from_jsonconfig("root", parsed);
 
-    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+    let htmlconfig = config.get_html_config();
 
     assert_eq!(htmlconfig.get_destination(), PathBuf::from("root/htmlbook"));
 }
@@ -81,7 +81,7 @@ fn from_json_output_html_theme() {
     let parsed = JsonConfig::from_json(json).expect("This should parse");
     let config = BookConfig::from_jsonconfig("root", parsed);
 
-    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+    let htmlconfig = config.get_html_config();
 
     assert_eq!(htmlconfig.get_theme(), &PathBuf::from("root/theme"));
 }

--- a/tests/tomlconfig.rs
+++ b/tests/tomlconfig.rs
@@ -68,7 +68,7 @@ fn from_toml_output_html_destination() {
     let parsed = TomlConfig::from_toml(toml).expect("This should parse");
     let config = BookConfig::from_tomlconfig("root", parsed);
 
-    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+    let htmlconfig = config.get_html_config();
 
     assert_eq!(htmlconfig.get_destination(), PathBuf::from("root/htmlbook"));
 }
@@ -82,7 +82,7 @@ fn from_toml_output_html_theme() {
     let parsed = TomlConfig::from_toml(toml).expect("This should parse");
     let config = BookConfig::from_tomlconfig("root", parsed);
 
-    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+    let htmlconfig = config.get_html_config();
 
     assert_eq!(htmlconfig.get_theme(), &PathBuf::from("root/theme"));
 }
@@ -96,7 +96,7 @@ fn from_toml_output_html_curly_quotes() {
     let parsed = TomlConfig::from_toml(toml).expect("This should parse");
     let config = BookConfig::from_tomlconfig("root", parsed);
 
-    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+    let htmlconfig = config.get_html_config();
 
     assert_eq!(htmlconfig.get_curly_quotes(), true);
 }
@@ -110,7 +110,7 @@ fn from_toml_output_html_mathjax_support() {
     let parsed = TomlConfig::from_toml(toml).expect("This should parse");
     let config = BookConfig::from_tomlconfig("root", parsed);
 
-    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+    let htmlconfig = config.get_html_config();
 
     assert_eq!(htmlconfig.get_mathjax_support(), true);
 }
@@ -124,7 +124,7 @@ fn from_toml_output_html_google_analytics() {
     let parsed = TomlConfig::from_toml(toml).expect("This should parse");
     let config = BookConfig::from_tomlconfig("root", parsed);
 
-    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+    let htmlconfig = config.get_html_config();
 
     assert_eq!(htmlconfig.get_google_analytics_id().expect("the google-analytics key was provided"), String::from("123456"));
 }
@@ -138,7 +138,7 @@ fn from_toml_output_html_additional_stylesheet() {
     let parsed = TomlConfig::from_toml(toml).expect("This should parse");
     let config = BookConfig::from_tomlconfig("root", parsed);
 
-    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+    let htmlconfig = config.get_html_config();
 
     assert_eq!(htmlconfig.get_additional_css(), &[PathBuf::from("root/custom.css"), PathBuf::from("root/two/custom.css")]);
 }
@@ -152,7 +152,7 @@ fn from_toml_output_html_additional_scripts() {
     let parsed = TomlConfig::from_toml(toml).expect("This should parse");
     let config = BookConfig::from_tomlconfig("root", parsed);
 
-    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+    let htmlconfig = config.get_html_config();
 
     assert_eq!(htmlconfig.get_additional_js(), &[PathBuf::from("root/custom.js"), PathBuf::from("root/two/custom.js")]);
 }


### PR DESCRIPTION
`HtmlConfig` was both guaranteed to exist within `BookConfig`
and `expect`ed in few places.
This simplifies the API a little by representing the fact that
`HtmlConfig` is curently mandatory for proper mdbook binary operation.

Please feel free to drop this PR if it does not match the project vision (it did not take a lot of effort anyway ;) ). 