### PR TITLE
Make MathJax support optional

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -498,6 +498,23 @@ impl MDBook {
         false
     }
 
+    pub fn with_mathjax_support(mut self, mathjax_support: bool) -> Self {
+        if let Some(htmlconfig) = self.config.get_mut_html_config() {
+            htmlconfig.set_mathjax_support(mathjax_support);
+        } else {
+            error!("There is no HTML renderer set...");
+        }
+        self
+    }
+
+    pub fn get_mathjax_support(&self) -> bool {
+        if let Some(htmlconfig) = self.config.get_html_config() {
+            return htmlconfig.get_mathjax_support();
+        }
+
+        false
+    }
+
     pub fn get_google_analytics_id(&self) -> Option<String> {
         if let Some(htmlconfig) = self.config.get_html_config() {
             return htmlconfig.get_google_analytics_id();

--- a/src/config/htmlconfig.rs
+++ b/src/config/htmlconfig.rs
@@ -7,6 +7,7 @@ pub struct HtmlConfig {
     destination: PathBuf,
     theme: PathBuf,
     curly_quotes: bool,
+    mathjax_support: bool,
     google_analytics: Option<String>,
     additional_css: Vec<PathBuf>,
     additional_js: Vec<PathBuf>,
@@ -30,6 +31,7 @@ impl HtmlConfig {
             destination: root.clone().join("book"),
             theme: root.join("theme"),
             curly_quotes: false,
+            mathjax_support: false,
             google_analytics: None,
             additional_css: Vec::new(),
             additional_js: Vec::new(),
@@ -49,6 +51,10 @@ impl HtmlConfig {
 
         if let Some(curly_quotes) = tomlconfig.curly_quotes {
             self.curly_quotes = curly_quotes;
+        }
+
+        if let Some(mathjax_support) = tomlconfig.mathjax_support {
+            self.mathjax_support = mathjax_support;
         }
 
         if tomlconfig.google_analytics.is_some() {
@@ -114,6 +120,14 @@ impl HtmlConfig {
 
     pub fn set_curly_quotes(&mut self, curly_quotes: bool) {
         self.curly_quotes = curly_quotes;
+    }
+
+    pub fn get_mathjax_support(&self) -> bool {
+        self.mathjax_support
+    }
+
+    pub fn set_mathjax_support(&mut self, mathjax_support: bool) {
+        self.mathjax_support = mathjax_support;
     }
 
     pub fn get_google_analytics_id(&self) -> Option<String> {

--- a/src/config/tomlconfig.rs
+++ b/src/config/tomlconfig.rs
@@ -25,6 +25,7 @@ pub struct TomlHtmlConfig {
     pub theme: Option<PathBuf>,
     pub google_analytics: Option<String>,
     pub curly_quotes: Option<bool>,
+    pub mathjax_support: Option<bool>,
     pub additional_css: Option<Vec<PathBuf>>,
     pub additional_js: Option<Vec<PathBuf>>,
 }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -318,6 +318,10 @@ fn make_data(book: &MDBook) -> Result<serde_json::Map<String, serde_json::Value>
         data.insert("google_analytics".to_owned(), json!(ga));
     }
 
+    if book.get_mathjax_support() {
+        data.insert("mathjax_support".to_owned(), json!(true));
+    }
+
     // Add check to see if there is an additional style
     if book.has_additional_css() {
         let mut css = Vec::new();

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -27,8 +27,10 @@
         <link rel="stylesheet" href="{{this}}">
         {{/each}}
 
+        {{#if mathjax_support}}
         <!-- MathJax -->
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        {{/if}}
 
         <!-- Fetch Clipboard.js from CDN but have a local fallback -->
         <script src="https://cdn.jsdelivr.net/clipboard.js/1.6.1/clipboard.min.js"></script>

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -15,7 +15,8 @@ fn do_not_overwrite_unspecified_config_values() {
 
     let book = MDBook::new(dir.path())
         .with_source("bar")
-        .with_destination("baz");
+        .with_destination("baz")
+        .with_mathjax_support(true);
 
     assert_eq!(book.get_root(), dir.path());
     assert_eq!(book.get_source(), dir.path().join("bar"));
@@ -27,6 +28,7 @@ fn do_not_overwrite_unspecified_config_values() {
     assert_eq!(book.get_root(), dir.path());
     assert_eq!(book.get_source(), dir.path().join("bar"));
     assert_eq!(book.get_destination().unwrap(), dir.path().join("baz"));
+    assert_eq!(book.get_mathjax_support(), true);
 
     // Try with a partial config file
     let file_path = dir.path().join("book.toml");
@@ -39,5 +41,6 @@ fn do_not_overwrite_unspecified_config_values() {
     assert_eq!(book.get_root(), dir.path());
     assert_eq!(book.get_source(), dir.path().join("barbaz"));
     assert_eq!(book.get_destination().unwrap(), dir.path().join("baz"));
+    assert_eq!(book.get_mathjax_support(), true);
 }
 

--- a/tests/tomlconfig.rs
+++ b/tests/tomlconfig.rs
@@ -101,6 +101,20 @@ fn from_toml_output_html_curly_quotes() {
     assert_eq!(htmlconfig.get_curly_quotes(), true);
 }
 
+// Tests that the `output.html.mathjax-support` key is correctly parsed in the TOML config
+#[test]
+fn from_toml_output_html_mathjax_support() {
+    let toml = r#"[output.html]
+    mathjax-support = true"#;
+
+    let parsed = TomlConfig::from_toml(&toml).expect("This should parse");
+    let config = BookConfig::from_tomlconfig("root", parsed);
+
+    let htmlconfig = config.get_html_config().expect("There should be an HtmlConfig");
+
+    assert_eq!(htmlconfig.get_mathjax_support(), true);
+}
+
 // Tests that the `output.html.google-analytics` key is correctly parsed in the TOML config
 #[test]
 fn from_toml_output_html_google_analytics() {


### PR DESCRIPTION
to enable add following to book.toml
```toml
[output.html]
mathjax-support = true
```

fixes https://github.com/azerupi/mdBook/issues/347