### PR TITLE
Print stdout when `mdbook test` failed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub mod errors {
         errors {
             Subprocess(message: String, output: ::std::process::Output) {
                 description("A subprocess failed")
+                display("{}: {}", message, String::from_utf8_lossy(&output.stdout))
             }
         }
     }


### PR DESCRIPTION
See https://github.com/azerupi/mdBook/pull/361#discussion_r124440165

Before:

```
[*]: Testing file: "/Users/messense/Projects/PyO3/guide/src/./conversions.md"
An error occured:
A subprocess failed
```

After:

```
[*]: Testing file: "/Users/messense/Projects/PyO3/guide/src/./conversions.md"
An error occured:
Rustdoc returned an error:
running 2 tests
test /Users/messense/Projects/PyO3/guide/src/./conversions.md - Type_Conversions (line 15) ... FAILED
test /Users/messense/Projects/PyO3/guide/src/./conversions.md - Type_Conversions (line 15) ... FAILED

failures:

---- /Users/messense/Projects/PyO3/guide/src/./conversions.md - Type_Conversions (line 15) stdout ----
	error[E0463]: can't find crate for `pyo3`
 --> <anon>:1:1
  |
1 | extern crate pyo3;
  | ^^^^^^^^^^^^^^^^^^ can't find crate

error: aborting due to previous error(s)

thread 'rustc' panicked at 'Box<Any>', src/librustc_errors/lib.rs:512
thread 'rustc' panicked at 'couldn't compile the test', src/librustdoc/test.rs:278

---- /Users/messense/Projects/PyO3/guide/src/./conversions.md - Type_Conversions (line 15) stdout ----
	error[E0463]: can't find crate for `pyo3`
 --> <anon>:1:1
  |
1 | extern crate pyo3;
  | ^^^^^^^^^^^^^^^^^^ can't find crate

error: aborting due to previous error(s)

thread 'rustc' panicked at 'Box<Any>', src/librustc_errors/lib.rs:512
note: Run with `RUST_BACKTRACE=1` for a backtrace.
thread 'rustc' panicked at 'couldn't compile the test', src/librustdoc/test.rs:278


failures:
    /Users/messense/Projects/PyO3/guide/src/./conversions.md - Type_Conversions (line 15)
    /Users/messense/Projects/PyO3/guide/src/./conversions.md - Type_Conversions (line 15)

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```