### PR TITLE
fix travis ci for beta channel

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -25,8 +25,9 @@ install_rustup() {
   popd
 
   rm -r $td
-
-  rustup default $CHANNEL
+  rustup self update
+  rustup install "$CHANNEL"
+  rustup default "$CHANNEL"
   rustc -V
   cargo -V
 }


### PR DESCRIPTION
travis started to fail for beta channel.
This is most likely due to old version on rustup on travis-ci