### PR TITLE
Fixed `mdbook test` for {{#playpen file.rs}}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ env_logger = "0.4.0"
 toml = { version = "0.4", features = ["serde"] }
 open = "1.1"
 regex = "0.2.1"
+tempdir = "0.3.4"
 
 # Watch feature
 notify = { version = "4.0", optional = true }
@@ -38,10 +39,6 @@ crossbeam = { version = "0.2.8", optional = true }
 iron = { version = "0.5", optional = true }
 staticfile = { version = "0.4", optional = true }
 ws = { version = "0.7", optional = true}
-
-# Tests
-[dev-dependencies]
-tempdir = "0.3.4"
 
 [build-dependencies]
 error-chain = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,6 @@ extern crate serde_derive;
 extern crate serde;
 #[macro_use]
 extern crate serde_json;
-
-#[cfg(test)]
 extern crate tempdir;
 
 mod parse;


### PR DESCRIPTION
- now `mdbook test` does full link expansion to temp file prior to running
- also *very* minor reformat and cleanup of `HtmlHandlebars::render_item`

fixes https://github.com/azerupi/mdBook/issues/391

IMHO the render_item should have a major overhaul. It might be good to start pulling some more of @Michael-F-Bryan 's book representation refactors.