### PR TITLE
Dynamic play button based on `no_run` property and used crates availability 

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -19,6 +19,9 @@ code {
 .hidden {
   display: none;
 }
+.play-button.hidden {
+  display: none;
+}
 h2,
 h3 {
   margin-top: 2.5em;

--- a/src/theme/stylus/general.styl
+++ b/src/theme/stylus/general.styl
@@ -24,6 +24,10 @@ code {
     display: none;
 }
 
+.play-button.hidden {
+    display: none;
+}
+
 h2, h3 { margin-top: 2.5em }
 h4, h5 { margin-top: 2em }
 


### PR DESCRIPTION
fixes https://github.com/azerupi/mdBook/issues/396

- list of available crates is dynamically loaded from play.rust-lang.org
- play button is enabled only if crates used in snippet are available on playground
- ACE editor's play button is dynamically updated on each text change
- `no_run` is honored by always disabling the play button
- minor cleanups/refactors

This might not be ready for prime time as currently the play button is just hidden if both on `no_run` and when using crates unavailable on play.rust-lang.org. I would like to eventually just disable the play button with some visual cue (dim/color change) and tooltip describing the state (I guess that It'll wait for https://github.com/azerupi/mdBook/issues/388 ;)).

But I wanted to push the WIP for review as soon as possible as I'll not have much free time on my hands for the next two weeks.

But OTOH it might be worth merging as it is anyway with later fix for nicer play button disabling. 