### PR TITLE
Fix toml problem and release 0.0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook"
-version = "0.0.22-pre"
+version = "0.0.23"
 authors = ["Mathieu David <mathieudavid@mathieudavid.org>"]
 description = "create books from markdown files (like Gitbook)"
 documentation = "http://azerupi.github.io/mdBook/index.html"
@@ -25,7 +25,7 @@ pulldown-cmark = "0.0.14"
 lazy_static = "0.2"
 log = "0.3"
 env_logger = "0.4.0"
-toml = { version = "0.4", features = ["serde"] }
+toml = "0.4"
 open = "1.1"
 regex = "0.2.1"
 tempdir = "0.3.4"


### PR DESCRIPTION
The toml crate removed its serde dependency in 0.3, but in 0.4, it
went away. Cargo didn't warn on this, but now it does. As such, we
need a release so that rust's build doesn't warn constantly.