### PR TITLE
[book] Prevent over-matching in gitignore rule

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -223,7 +223,7 @@ impl MDBook {
 
             debug!("[*]: Writing to .gitignore");
 
-            writeln!(f, "{}", relative).expect("Could not write to file.");
+            writeln!(f, "/{}", relative).expect("Could not write to file.");
         }
     }
 


### PR DESCRIPTION
To only ignore the output destination (default: `book`) and no other
file/directory with the same name under the mdbook root, we should
prefix the gitignore rule with a leading slash (default: `/book`).