### PR TITLE
[Cargo.toml] Fix package.exclude warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 build = "build.rs"
 exclude = [
     "book-example/*",
-    "src/theme/stylus",
+    "src/theme/stylus/**",
 ]
 
 [dependencies]

--- a/src/bin/watch.rs
+++ b/src/bin/watch.rs
@@ -1,6 +1,4 @@
 extern crate notify;
-extern crate time;
-extern crate crossbeam;
 
 use std::path::Path;
 use self::notify::Watcher;


### PR DESCRIPTION
IIUC, the existing exclude rule has meant to do what it will do in the
future (gitignore-like matching, not glob-only matching). This fix makes
the rule to do what it was expected to do, and is forward-compatible,
therefore fixing the warning messages.