### PR TITLE
Do not trigger spurious watch events on Write and Remove

### DIFF
--- a/src/bin/watch.rs
+++ b/src/bin/watch.rs
@@ -98,8 +98,6 @@ pub fn trigger_on_change<F>(book: &mut MDBook, closure: F) -> ()
         match rx.recv() {
             Ok(event) => {
                 match event {
-                    NoticeWrite(path) |
-                    NoticeRemove(path) |
                     Create(path) |
                     Write(path) |
                     Remove(path) |


### PR DESCRIPTION
related to https://github.com/azerupi/mdBook/issues/383

This PR might not solve the #383 completely, I do not have kate installed (nor willing to pull halve of kde to test it ;) but it solves an annoying double/triple build on each file edit with vim on my system.