### PR TITLE
Fix some clippy warnings

### DIFF
--- a/src/bin/watch.rs
+++ b/src/bin/watch.rs
@@ -73,7 +73,7 @@ where
         Ok(w) => w,
         Err(e) => {
             println!("Error while trying to watch the files:\n\n\t{:?}", e);
-            ::std::process::exit(0);
+            ::std::process::exit(0)
         }
     };
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -79,7 +79,7 @@ impl HtmlHandlebars {
                 let filepath = Path::new(&ch.path).with_extension("html");
                 let rendered = self.post_process(
                     rendered,
-                    &normalize_path(filepath.to_str().ok_or(Error::from(
+                    &normalize_path(filepath.to_str().ok_or_else(|| Error::from(
                         format!("Bad file name: {}", filepath.display()),
                     ))?),
                     ctx.book.get_html_config().get_playpen_config(),
@@ -129,8 +129,8 @@ impl HtmlHandlebars {
                     filepath: &str,
                     playpen_config: &PlaypenConfig)
                     -> String {
-        let rendered = build_header_links(&rendered, &filepath);
-        let rendered = fix_anchor_links(&rendered, &filepath);
+        let rendered = build_header_links(&rendered, filepath);
+        let rendered = fix_anchor_links(&rendered, filepath);
         let rendered = fix_code_blocks(&rendered);
         let rendered = add_playpen_pre(&rendered, playpen_config);
 
@@ -470,7 +470,7 @@ fn id_from_content(content: &str) -> String {
     }
 
     // Remove spaces and hastags indicating a header
-    let trimmed = content.trim().trim_left_matches("#").trim();
+    let trimmed = content.trim().trim_left_matches('#').trim();
 
     normalize_id(trimmed)
 }


### PR DESCRIPTION
In response to #458.

I did not fix two of clippy's warnings:

```
warning: returning the result of a let binding from a block. Consider returning the expression directly.
   --> src/renderer/html_handlebars/hbs_renderer.rs:137:9
    |
137 |         rendered
    |         ^^^^^^^^
    |
    = note: #[warn(let_and_return)] on by default
note: this expression can be directly returned
   --> src/renderer/html_handlebars/hbs_renderer.rs:135:24
    |
135 |         let rendered = add_playpen_pre(&rendered, playpen_config);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#let_and_return
```

I think the code is more readable as it is currently than clippy's suggestion. Should I add 
`#[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]` or are warnings okay here?


```
warning: large size difference between variants
   --> src/lib.rs:104:5
    |
104 | /     error_chain!{
105 | |         foreign_links {
106 | |             Io(::std::io::Error);
107 | |             HandlebarsRender(::handlebars::RenderError);
...   |
117 | |         }
118 | |     }
    | |_____^
    |
    = note: #[warn(large_enum_variant)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
    |
113 | err : Box<$ foreign_link_error_path> ) {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Not sure what to do about this one. Boxing the errors seems more invasive, so I'll leave that decision to someone else. I don't see why any of these variants should be large though.