### PR TITLE
Use absolute positioning for theme popup

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -266,7 +266,7 @@ table thead td {
   left: 315px;
 }
 .theme-popup {
-  position: relative;
+  position: absolute;
   left: 10px;
   z-index: 1000;
   border-radius: 4px;

--- a/src/theme/stylus/theme-popup.styl
+++ b/src/theme/stylus/theme-popup.styl
@@ -1,5 +1,5 @@
 .theme-popup {
-    position: relative
+    position: absolute
     left: 10px
 
     z-index: 1000;


### PR DESCRIPTION
This prevents the theme popup from pushing around the text below it.